### PR TITLE
Add Sort stage to Aggregation

### DIFF
--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/aggregates/Aggregation.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/aggregates/Aggregation.scala
@@ -1,18 +1,21 @@
 package io.github.zeal18.zio.mongodb.driver.aggregates
 
+import scala.annotation.nowarn
+import scala.reflect.ClassTag
+
 import io.github.zeal18.zio.mongodb.bson.BsonDocument
 import io.github.zeal18.zio.mongodb.bson.codecs.Codec
 import io.github.zeal18.zio.mongodb.driver.aggregates.accumulators.Accumulator
 import io.github.zeal18.zio.mongodb.driver.filters.Filter
 import io.github.zeal18.zio.mongodb.driver.projections.Projection
 import io.github.zeal18.zio.mongodb.driver.sorts
-import org.bson.{BsonBoolean, BsonDocumentWriter, BsonInt32, BsonString}
+import org.bson.BsonBoolean
+import org.bson.BsonDocumentWriter
+import org.bson.BsonInt32
+import org.bson.BsonString
 import org.bson.codecs.EncoderContext
 import org.bson.codecs.configuration.CodecRegistry
 import org.bson.conversions.Bson
-
-import scala.annotation.nowarn
-import scala.reflect.ClassTag
 
 sealed trait Aggregation extends Bson { self =>
   @nowarn("msg=possible missing interpolator*")
@@ -152,7 +155,7 @@ sealed trait Aggregation extends Bson { self =>
       case Aggregation.Sort(sort) =>
         new BsonDocument(
           "$sort",
-          sort.toBsonDocument(documentClass, codecRegistry)
+          sort.toBsonDocument(documentClass, codecRegistry),
         )
       case Aggregation.Lookup(from, localField, foreignField, as) =>
         new BsonDocument(

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/aggregates/package.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/aggregates/package.scala
@@ -4,7 +4,9 @@ import io.github.zeal18.zio.mongodb.bson.codecs.Codec
 import io.github.zeal18.zio.mongodb.driver.aggregates.Aggregation.*
 import io.github.zeal18.zio.mongodb.driver.aggregates.accumulators.Accumulator
 import io.github.zeal18.zio.mongodb.driver.filters.Filter
+import io.github.zeal18.zio.mongodb.driver.filters.Filter.Expr
 import io.github.zeal18.zio.mongodb.driver.projections.Projection
+import io.github.zeal18.zio.mongodb.driver.sorts.Sort
 import org.bson.BsonDocument
 import org.bson.conversions.Bson
 
@@ -144,6 +146,15 @@ package object aggregates {
     */
   def unwind(fieldName: String, unwindOptions: UnwindOptions): Unwind =
     Unwind(fieldName, unwindOptions)
+
+  /**
+    * Creates a `\$sort` pipeline stage for the specified sort specification
+    *
+    * @param sort the sort specification
+    * @see Sorts
+    * @see [[http://docs.mongodb.org/manual/reference/operator/aggregation/sort/#sort-aggregation \$sort]]
+    */
+  def sort(sort: sorts.Sort): Aggregation.Sort = Aggregation.Sort(sort)
 
   /** Creates a pipeline from a raw Bson.
     *

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/aggregates/package.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/aggregates/package.scala
@@ -4,9 +4,7 @@ import io.github.zeal18.zio.mongodb.bson.codecs.Codec
 import io.github.zeal18.zio.mongodb.driver.aggregates.Aggregation.*
 import io.github.zeal18.zio.mongodb.driver.aggregates.accumulators.Accumulator
 import io.github.zeal18.zio.mongodb.driver.filters.Filter
-import io.github.zeal18.zio.mongodb.driver.filters.Filter.Expr
 import io.github.zeal18.zio.mongodb.driver.projections.Projection
-import io.github.zeal18.zio.mongodb.driver.sorts.Sort
 import org.bson.BsonDocument
 import org.bson.conversions.Bson
 
@@ -147,8 +145,7 @@ package object aggregates {
   def unwind(fieldName: String, unwindOptions: UnwindOptions): Unwind =
     Unwind(fieldName, unwindOptions)
 
-  /**
-    * Creates a `\$sort` pipeline stage for the specified sort specification
+  /** Creates a `\$sort` pipeline stage for the specified sort specification
     *
     * @param sort the sort specification
     * @see Sorts

--- a/driver/src/test/scala/io/github/zeal18/zio/mongodb/driver/aggregates/AggregatesSpec.scala
+++ b/driver/src/test/scala/io/github/zeal18/zio/mongodb/driver/aggregates/AggregatesSpec.scala
@@ -1,15 +1,10 @@
 package io.github.zeal18.zio.mongodb.driver.aggregates
 
-import scala.annotation.nowarn
-
 import io.github.zeal18.zio.mongodb.bson.BsonDocument
-import io.github.zeal18.zio.mongodb.driver.aggregates
-import io.github.zeal18.zio.mongodb.driver.aggregates.UnwindOptions
-import io.github.zeal18.zio.mongodb.driver.aggregates.accumulators
-import io.github.zeal18.zio.mongodb.driver.filters
-import io.github.zeal18.zio.mongodb.driver.projections
-import zio.test.ZIOSpecDefault
+import io.github.zeal18.zio.mongodb.driver.{aggregates, filters, projections, sorts}
 import zio.test.*
+
+import scala.annotation.nowarn
 
 object AggregatesSpec extends ZIOSpecDefault {
   private def testAggregate(
@@ -38,6 +33,11 @@ object AggregatesSpec extends ZIOSpecDefault {
       """{"$facet": {"a": [{"$count": "count"}], "b": [{"$match": {"_id": 42}}]}}""",
     ),
     testAggregate("limit", aggregates.limit(43), """{"$limit": 43}"""),
+    testAggregate(
+      "sort",
+      aggregates.sort(sorts.compound(sorts.asc("a", "b"), sorts.desc("c", "d"))),
+      """{"$sort": {"a": 1, "b": 1, "c": -1, "d": -1}}"""
+    ),
     testAggregate(
       "group",
       aggregates.group("a", accumulators.sum("b", 1)),

--- a/driver/src/test/scala/io/github/zeal18/zio/mongodb/driver/aggregates/AggregatesSpec.scala
+++ b/driver/src/test/scala/io/github/zeal18/zio/mongodb/driver/aggregates/AggregatesSpec.scala
@@ -1,10 +1,13 @@
 package io.github.zeal18.zio.mongodb.driver.aggregates
 
-import io.github.zeal18.zio.mongodb.bson.BsonDocument
-import io.github.zeal18.zio.mongodb.driver.{aggregates, filters, projections, sorts}
-import zio.test.*
-
 import scala.annotation.nowarn
+
+import io.github.zeal18.zio.mongodb.bson.BsonDocument
+import io.github.zeal18.zio.mongodb.driver.aggregates
+import io.github.zeal18.zio.mongodb.driver.filters
+import io.github.zeal18.zio.mongodb.driver.projections
+import io.github.zeal18.zio.mongodb.driver.sorts
+import zio.test.*
 
 object AggregatesSpec extends ZIOSpecDefault {
   private def testAggregate(
@@ -36,7 +39,7 @@ object AggregatesSpec extends ZIOSpecDefault {
     testAggregate(
       "sort",
       aggregates.sort(sorts.compound(sorts.asc("a", "b"), sorts.desc("c", "d"))),
-      """{"$sort": {"a": 1, "b": 1, "c": -1, "d": -1}}"""
+      """{"$sort": {"a": 1, "b": 1, "c": -1, "d": -1}}""",
     ),
     testAggregate(
       "group",


### PR DESCRIPTION
I added the Sort stage to the aggregation pipelines, I reused the `Sorts` from `io.github.zeal18.zio.mongodb.driver.sorts`