### PR TITLE
Implement in-memory subscribers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ val zioVersion          = "2.0.3"
 val zioInteropRSVersion = "2.0.0"
 
 val mongoVersion = "4.6.1"
+val rsVersion    = "1.0.4"
 
 val flapdoodleVersion = "3.4.11"
 val immutablesVersion = "2.9.2"
@@ -129,11 +130,12 @@ lazy val driver: Project = (project in file("driver"))
     // [error] This is likely due to an implementation restriction: an annotation argument cannot refer to a member of the annotated class (scala/bug#7014).
     scalacOptions += "-Wconf:msg=While parsing annotations in:silent",
     libraryDependencies ++= Seq(
-      "dev.zio"    %% "zio"                            % zioVersion,
-      "dev.zio"    %% "zio-interop-reactivestreams"    % zioInteropRSVersion,
-      "org.mongodb" % "mongodb-driver-reactivestreams" % mongoVersion,
-      "dev.zio"    %% "zio-test"                       % zioVersion % Test,
-      "dev.zio"    %% "zio-test-sbt"                   % zioVersion % Test,
+      "dev.zio"            %% "zio"                            % zioVersion,
+      "dev.zio"            %% "zio-interop-reactivestreams"    % zioInteropRSVersion,
+      "org.mongodb"         % "mongodb-driver-reactivestreams" % mongoVersion,
+      "org.reactivestreams" % "reactive-streams-tck"           % rsVersion  % Test,
+      "dev.zio"            %% "zio-test"                       % zioVersion % Test,
+      "dev.zio"            %% "zio-test-sbt"                   % zioVersion % Test,
     ),
   )
   .dependsOn(bson)

--- a/driver-it-tests/src/it/scala/io/github/zeal18/zio/mongodb/driver/FiltersItSpec.scala
+++ b/driver-it-tests/src/it/scala/io/github/zeal18/zio/mongodb/driver/FiltersItSpec.scala
@@ -28,8 +28,8 @@ object FiltersItSpec extends ZIOSpecDefault {
             for {
               _ <- collection.insertMany(Chunk(person1, person2))
 
-              result1 <- collection.find(filters.eq(42)).execute.runCollect
-              result2 <- collection.find(filters.eq(43)).execute.runCollect
+              result1 <- collection.find(filters.eq(42)).runToChunk
+              result2 <- collection.find(filters.eq(43)).runToChunk
             } yield assertTrue(result1 == Chunk(person1), result2 == Chunk(person2))
           }
         },
@@ -41,8 +41,8 @@ object FiltersItSpec extends ZIOSpecDefault {
             for {
               _ <- collection.insertMany(Chunk(person1, person2))
 
-              result1 <- collection.find(filters.eq("name", "foo")).execute.runCollect
-              result2 <- collection.find(filters.eq("name", "bar")).execute.runCollect
+              result1 <- collection.find(filters.eq("name", "foo")).runToChunk
+              result2 <- collection.find(filters.eq("name", "bar")).runToChunk
             } yield assertTrue(result1 == Chunk(person1), result2 == Chunk(person2))
           }
         },
@@ -55,7 +55,7 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(person1, person2))
 
-            result1 <- collection.find(filters.ne("name", "foo")).execute.runCollect
+            result1 <- collection.find(filters.ne("name", "foo")).runToChunk
           } yield assertTrue(result1 == Chunk(person2))
         }
       },
@@ -68,7 +68,7 @@ object FiltersItSpec extends ZIOSpecDefault {
             for {
               _ <- collection.insertMany(Chunk(person1, person2))
 
-              result1 <- collection.find(filters.gt("_id", 42)).execute.runCollect
+              result1 <- collection.find(filters.gt("_id", 42)).runToChunk
             } yield assertTrue(result1 == Chunk(person2))
           }
         },
@@ -80,7 +80,7 @@ object FiltersItSpec extends ZIOSpecDefault {
             for {
               _ <- collection.insertMany(Chunk(person1, person2))
 
-              result1 <- collection.find(filters.gte("_id", 43)).execute.runCollect
+              result1 <- collection.find(filters.gte("_id", 43)).runToChunk
             } yield assertTrue(result1 == Chunk(person2))
           }
         },
@@ -94,7 +94,7 @@ object FiltersItSpec extends ZIOSpecDefault {
             for {
               _ <- collection.insertMany(Chunk(person1, person2))
 
-              result1 <- collection.find(filters.lt("_id", 43)).execute.runCollect
+              result1 <- collection.find(filters.lt("_id", 43)).runToChunk
             } yield assertTrue(result1 == Chunk(person1))
           }
         },
@@ -106,7 +106,7 @@ object FiltersItSpec extends ZIOSpecDefault {
             for {
               _ <- collection.insertMany(Chunk(person1, person2))
 
-              result1 <- collection.find(filters.lte("_id", 42)).execute.runCollect
+              result1 <- collection.find(filters.lte("_id", 42)).runToChunk
             } yield assertTrue(result1 == Chunk(person1))
           }
         },
@@ -120,8 +120,8 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(person1, person2, person3))
 
-            result1 <- collection.find(filters.in("_id", Seq(42, 44))).execute.runCollect
-            result2 <- collection.find(filters.in("name", Seq("bar"))).execute.runCollect
+            result1 <- collection.find(filters.in("_id", Seq(42, 44))).runToChunk
+            result2 <- collection.find(filters.in("name", Seq("bar"))).runToChunk
           } yield assertTrue(result1 == Chunk(person1, person3), result2 == Chunk(person2))
         }
       },
@@ -134,8 +134,8 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(person1, person2, person3))
 
-            result1 <- collection.find(filters.nin("_id", Seq(42, 44))).execute.runCollect
-            result2 <- collection.find(filters.nin("name", Seq("bar"))).execute.runCollect
+            result1 <- collection.find(filters.nin("_id", Seq(42, 44))).runToChunk
+            result2 <- collection.find(filters.nin("name", Seq("bar"))).runToChunk
           } yield assertTrue(result1 == Chunk(person2), result2 == Chunk(person1, person3))
         }
       },
@@ -155,8 +155,7 @@ object FiltersItSpec extends ZIOSpecDefault {
                   filters.eq("name", "baz"),
                 ),
               )
-              .execute
-              .runCollect
+              .runToChunk
           } yield assertTrue(result1 == Chunk(person3))
         }
       },
@@ -176,8 +175,7 @@ object FiltersItSpec extends ZIOSpecDefault {
                   filters.eq("name", "baz"),
                 ),
               )
-              .execute
-              .runCollect
+              .runToChunk
           } yield assertTrue(result1 == Chunk(person1, person3))
         }
       },
@@ -197,8 +195,7 @@ object FiltersItSpec extends ZIOSpecDefault {
                   filters.eq("name", "baz"),
                 ),
               )
-              .execute
-              .runCollect
+              .runToChunk
           } yield assertTrue(result1 == Chunk(person2))
         }
       },
@@ -211,7 +208,7 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(person1, person2, person3))
 
-            result1 <- collection.find(filters.not(filters.eq(43))).execute.runCollect
+            result1 <- collection.find(filters.not(filters.eq(43))).runToChunk
           } yield assertTrue(result1 == Chunk(person1, person3))
         }
       },
@@ -221,10 +218,10 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertOne(doc)
 
-            result1 <- collection.find(filters.exists("foo", true)).execute.runCollect
-            result2 <- collection.find(filters.exists("foo", false)).execute.runCollect
-            result3 <- collection.find(filters.exists("baz", true)).execute.runCollect
-            result4 <- collection.find(filters.exists("baz", false)).execute.runCollect
+            result1 <- collection.find(filters.exists("foo", true)).runToChunk
+            result2 <- collection.find(filters.exists("foo", false)).runToChunk
+            result3 <- collection.find(filters.exists("baz", true)).runToChunk
+            result4 <- collection.find(filters.exists("baz", false)).runToChunk
           } yield assertTrue(
             result1 == Chunk(doc),
             result2 == Chunk.empty,
@@ -239,9 +236,9 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertOne(doc)
 
-            result1 <- collection.find(filters.`type`("foo", BsonType.STRING)).execute.runCollect
-            result2 <- collection.find(filters.`type`("foo", BsonType.INT32)).execute.runCollect
-            result3 <- collection.find(filters.`type`("baz", BsonType.STRING)).execute.runCollect
+            result1 <- collection.find(filters.`type`("foo", BsonType.STRING)).runToChunk
+            result2 <- collection.find(filters.`type`("foo", BsonType.INT32)).runToChunk
+            result3 <- collection.find(filters.`type`("baz", BsonType.STRING)).runToChunk
           } yield assertTrue(
             result1 == Chunk(doc),
             result2 == Chunk.empty,
@@ -258,7 +255,7 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(person1, person2, person3))
 
-            result1 <- collection.find(filters.regex("name", "ba.?")).execute.runCollect
+            result1 <- collection.find(filters.regex("name", "ba.?")).runToChunk
           } yield assertTrue(result1 == Chunk(person2, person3))
         }
       },
@@ -271,8 +268,8 @@ object FiltersItSpec extends ZIOSpecDefault {
             _ <- collection.createIndex(indexes.text("name"))
             _ <- collection.insertMany(Chunk(person1, person2))
 
-            result1 <- collection.find(filters.text("bar")).execute.runCollect
-            result2 <- collection.find(filters.text("foo")).execute.runCollect
+            result1 <- collection.find(filters.text("bar")).runToChunk
+            result2 <- collection.find(filters.text("foo")).runToChunk
           } yield assertTrue(result1.toSet == Set(person1, person2), result2 == Chunk(person1))
         }
       },
@@ -290,8 +287,7 @@ object FiltersItSpec extends ZIOSpecDefault {
                   """function() { return (hex_md5(this.name) == "9b53e667f30cd329dca1ec9e6a83e994") }""",
                 ),
               )
-              .execute
-              .runCollect
+              .runToChunk
           } yield assertTrue(result1.toSet == Set(person2))
         }
       },
@@ -308,8 +304,7 @@ object FiltersItSpec extends ZIOSpecDefault {
 
             result <- collection
               .find(filters.expr(aggregates.raw("""{"$gt": ["$spent", "$budget"]}""")))
-              .execute
-              .runCollect
+              .runToChunk
           } yield assertTrue(result == Chunk(doc1, doc2, doc5))
         }
       },
@@ -324,7 +319,7 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(doc1, doc2, doc3, doc4, doc5))
 
-            result <- collection.find(filters.mod("budget", 2, 0)).execute.runCollect
+            result <- collection.find(filters.mod("budget", 2, 0)).runToChunk
           } yield assertTrue(result == Chunk(doc1, doc5))
         }
       },
@@ -337,7 +332,7 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(doc1, doc2, doc3))
 
-            result1 <- collection.find(filters.all("tags", Chunk("A", "C"))).execute.runCollect
+            result1 <- collection.find(filters.all("tags", Chunk("A", "C"))).runToChunk
           } yield assertTrue(result1.toSet == Set(doc1, doc3))
         }
       },
@@ -353,8 +348,7 @@ object FiltersItSpec extends ZIOSpecDefault {
               .find(
                 filters.elemMatch("results", filters.raw("""{"$gte": 80, "$lte": 85}""")),
               )
-              .execute
-              .runCollect
+              .runToChunk
           } yield assertTrue(result1.toSet == Set(doc1))
         }
       },
@@ -367,9 +361,9 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(doc1, doc2, doc3))
 
-            result1 <- collection.find(filters.size("results", 1)).execute.runCollect
-            result2 <- collection.find(filters.size("results", 2)).execute.runCollect
-            result3 <- collection.find(filters.size("results", 3)).execute.runCollect
+            result1 <- collection.find(filters.size("results", 1)).runToChunk
+            result2 <- collection.find(filters.size("results", 2)).runToChunk
+            result3 <- collection.find(filters.size("results", 3)).runToChunk
           } yield assertTrue(result1 == Chunk(doc1), result2 == Chunk(doc2), result3 == Chunk(doc3))
         }
       },
@@ -381,12 +375,9 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(doc1, doc2))
 
-            result1 <- collection.find(filters.bitsAllClear("a", 1)).execute.runCollect // 0000 0001
-            result2 <- collection.find(filters.bitsAllClear("a", 9)).execute.runCollect // 0000 1001
-            result3 <- collection
-              .find(filters.bitsAllClear("a", 41))
-              .execute
-              .runCollect // 0010 0001
+            result1 <- collection.find(filters.bitsAllClear("a", 1)).runToChunk  // 0000 0001
+            result2 <- collection.find(filters.bitsAllClear("a", 9)).runToChunk  // 0000 1001
+            result3 <- collection.find(filters.bitsAllClear("a", 41)).runToChunk // 0010 0001
           } yield assertTrue(
             result1 == Chunk(doc1, doc2),
             result2 == Chunk(doc1, doc2),
@@ -402,8 +393,8 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(doc1, doc2))
 
-            result1 <- collection.find(filters.bitsAllSet("a", 20)).execute.runCollect // 0001 0100
-            result2 <- collection.find(filters.bitsAllSet("a", 22)).execute.runCollect // 0001 0110
+            result1 <- collection.find(filters.bitsAllSet("a", 20)).runToChunk // 0001 0100
+            result2 <- collection.find(filters.bitsAllSet("a", 22)).runToChunk // 0001 0110
           } yield assertTrue(
             result1 == Chunk(doc1, doc2),
             result2 == Chunk(doc1),
@@ -418,11 +409,8 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(doc1, doc2))
 
-            result1 <- collection.find(filters.bitsAnyClear("a", 6)).execute.runCollect // 0000 0110
-            result2 <- collection
-              .find(filters.bitsAnyClear("a", 14))
-              .execute
-              .runCollect // 0000 1110
+            result1 <- collection.find(filters.bitsAnyClear("a", 6)).runToChunk  // 0000 0110
+            result2 <- collection.find(filters.bitsAnyClear("a", 14)).runToChunk // 0000 1110
           } yield assertTrue(
             result1 == Chunk(doc2),
             result2 == Chunk(doc1, doc2),
@@ -437,8 +425,8 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(doc1, doc2))
 
-            result1 <- collection.find(filters.bitsAnySet("a", 96)).execute.runCollect // 0110 0000
-            result2 <- collection.find(filters.bitsAnySet("a", 12)).execute.runCollect // 0000 1100
+            result1 <- collection.find(filters.bitsAnySet("a", 96)).runToChunk // 0110 0000
+            result2 <- collection.find(filters.bitsAnySet("a", 12)).runToChunk // 0000 1100
           } yield assertTrue(
             result1 == Chunk(doc1),
             result2 == Chunk(doc1, doc2),
@@ -463,7 +451,7 @@ object FiltersItSpec extends ZIOSpecDefault {
           for {
             _ <- collection.insertMany(Chunk(doc1, doc2))
 
-            result <- collection.find(filters.jsonSchema(schema)).execute.runCollect
+            result <- collection.find(filters.jsonSchema(schema)).runToChunk
           } yield assertTrue(
             result == Chunk(doc2),
           )
@@ -478,8 +466,8 @@ object FiltersItSpec extends ZIOSpecDefault {
             for {
               _ <- collection.insertMany(Chunk(person1, person2))
 
-              result1 <- collection.find(filters.raw(Document("name" -> "foo"))).execute.runCollect
-              result2 <- collection.find(filters.raw(Document("name" -> "bar"))).execute.runCollect
+              result1 <- collection.find(filters.raw(Document("name" -> "foo"))).runToChunk
+              result2 <- collection.find(filters.raw(Document("name" -> "bar"))).runToChunk
             } yield assertTrue(result1 == Chunk(person1), result2 == Chunk(person2))
           }
         },
@@ -491,8 +479,8 @@ object FiltersItSpec extends ZIOSpecDefault {
             for {
               _ <- collection.insertMany(Chunk(person1, person2))
 
-              result1 <- collection.find(filters.raw("""{"name": "foo"}""")).execute.runCollect
-              result2 <- collection.find(filters.raw("""{"name": "bar"}""")).execute.runCollect
+              result1 <- collection.find(filters.raw("""{"name": "foo"}""")).runToChunk
+              result2 <- collection.find(filters.raw("""{"name": "bar"}""")).runToChunk
             } yield assertTrue(result1 == Chunk(person1), result2 == Chunk(person2))
           }
         },

--- a/driver-it-tests/src/it/scala/io/github/zeal18/zio/mongodb/driver/MongoCollectionSpec.scala
+++ b/driver-it-tests/src/it/scala/io/github/zeal18/zio/mongodb/driver/MongoCollectionSpec.scala
@@ -130,7 +130,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
               indexName <- collection.createIndex(indexes.asc("a"))
               _         <- collection.dropIndex(indexName)
 
-              indexes <- collection.listIndexes().execute.runCollect
+              indexes <- collection.listIndexes().runToChunk
             } yield assertTrue(indexes.size == 1) // only the _id index remains
           }
         },
@@ -140,7 +140,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
               indexName <- collection.createIndex(indexes.asc("a"))
               _         <- collection.dropIndex(indexName, DropIndexOptions(10.seconds))
 
-              indexes <- collection.listIndexes().execute.runCollect
+              indexes <- collection.listIndexes().runToChunk
             } yield assertTrue(indexes.size == 1) // only the _id index remains
           }
         },
@@ -152,7 +152,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
               _ <- collection.createIndex(indexKey)
               _ <- collection.dropIndex(indexKey)
 
-              indexes <- collection.listIndexes().execute.runCollect
+              indexes <- collection.listIndexes().runToChunk
             } yield assertTrue(indexes.size == 1) // only the _id index remains
           }
         },
@@ -164,7 +164,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
               _ <- collection.createIndex(indexKey)
               _ <- collection.dropIndex(indexKey, DropIndexOptions(10.seconds))
 
-              indexes <- collection.listIndexes().execute.runCollect
+              indexes <- collection.listIndexes().runToChunk
             } yield assertTrue(indexes.size == 1) // only the _id index remains
           }
         },
@@ -178,7 +178,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
                 }
               }
 
-              indexes <- collection.listIndexes().execute.runCollect
+              indexes <- collection.listIndexes().runToChunk
             } yield assertTrue(indexes.size == 1) // only the _id index remains
           }
         },
@@ -192,7 +192,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
                 }
               }
 
-              indexes <- collection.listIndexes().execute.runCollect
+              indexes <- collection.listIndexes().runToChunk
             } yield assertTrue(indexes.size == 1) // only the _id index remains
           }
         },
@@ -208,7 +208,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
                 }
               }
 
-              indexes <- collection.listIndexes().execute.runCollect
+              indexes <- collection.listIndexes().runToChunk
             } yield assertTrue(indexes.size == 1) // only the _id index remains
           }
         },
@@ -224,7 +224,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
                 }
               }
 
-              indexes <- collection.listIndexes().execute.runCollect
+              indexes <- collection.listIndexes().runToChunk
             } yield assertTrue(indexes.size == 1) // only the _id index remains
           }
         },
@@ -238,7 +238,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
 
               _ <- collection.dropIndexes()
 
-              indexes <- collection.listIndexes().execute.runCollect
+              indexes <- collection.listIndexes().runToChunk
             } yield assertTrue(indexes.size == 1) // only the _id index remains
           }
         },
@@ -250,7 +250,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
 
               _ <- collection.dropIndexes(DropIndexOptions(10.seconds))
 
-              indexes <- collection.listIndexes().execute.runCollect
+              indexes <- collection.listIndexes().runToChunk
             } yield assertTrue(indexes.size == 1) // only the _id index remains
           }
         },
@@ -266,7 +266,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
                 }
               }
 
-              indexes <- collection.listIndexes().execute.runCollect
+              indexes <- collection.listIndexes().runToChunk
             } yield assertTrue(indexes.size == 1) // only the _id index remains
           }
         },
@@ -282,7 +282,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
                 }
               }
 
-              indexes <- collection.listIndexes().execute.runCollect
+              indexes <- collection.listIndexes().runToChunk
             } yield assertTrue(indexes.size == 1) // only the _id index remains
           }
         },
@@ -296,7 +296,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
             for {
               _ <- collection.insertOne(model)
 
-              result <- collection.find().execute.runCollect
+              result <- collection.find().runToChunk
             } yield assertTrue(result == Chunk(model))
           }
         },
@@ -313,7 +313,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
                   .withComment(new BsonString("foo")),
               )
 
-              result <- collection.find().execute.runCollect
+              result <- collection.find().runToChunk
             } yield assertTrue(result == Chunk(model))
           }
         },
@@ -329,7 +329,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
                 }
               }
 
-              result <- collection.find().execute.runCollect
+              result <- collection.find().runToChunk
             } yield assertTrue(result == Chunk(model))
           }
         },
@@ -351,7 +351,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
                 }
               }
 
-              result <- collection.find().execute.runCollect
+              result <- collection.find().runToChunk
             } yield assertTrue(result == Chunk(model))
           }
         },
@@ -366,7 +366,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
             for {
               _ <- collection.insertMany(Chunk(model1, model2))
 
-              result <- collection.find().execute.runCollect
+              result <- collection.find().runToChunk
             } yield assertTrue(result == Chunk(model1, model2))
           }
         },
@@ -385,7 +385,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
                   .withComment(new BsonString("foo")),
               )
 
-              result <- collection.find().execute.runCollect
+              result <- collection.find().runToChunk
             } yield assertTrue(result == Chunk(model1, model2))
           }
         },
@@ -402,7 +402,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
                 }
               }
 
-              result <- collection.find().execute.runCollect
+              result <- collection.find().runToChunk
             } yield assertTrue(result == Chunk(model1, model2))
           }
         },
@@ -426,7 +426,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
                 }
               }
 
-              result <- collection.find().execute.runCollect
+              result <- collection.find().runToChunk
             } yield assertTrue(result == Chunk(model1, model2))
           }
         },
@@ -441,7 +441,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
             for {
               _ <- collection.insertMany(Chunk(model1, model2))
 
-              result <- collection.find(filters.eq("a", 43)).execute.runCollect
+              result <- collection.find(filters.eq("a", 43)).runToChunk
             } yield assertTrue(result == Chunk(model2))
           }
         },
@@ -456,7 +456,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
 
               result <- ZIO.scoped[Any] {
                 collection.startSession().flatMap { session =>
-                  collection.find(session).execute.runCollect
+                  collection.find(session).runToChunk
                 }
               }
             } yield assertTrue(result == Chunk(model1, model2))
@@ -473,7 +473,7 @@ object MongoCollectionSpec extends ZIOSpecDefault {
 
               result <- ZIO.scoped[Any] {
                 collection.startSession().flatMap { session =>
-                  collection.find(session, filters.eq("a", 43)).execute.runCollect
+                  collection.find(session, filters.eq("a", 43)).runToChunk
                 }
               }
             } yield assertTrue(result == Chunk(model2))

--- a/driver-it-tests/src/it/scala/io/github/zeal18/zio/mongodb/driver/MongoDatabaseSpec.scala
+++ b/driver-it-tests/src/it/scala/io/github/zeal18/zio/mongodb/driver/MongoDatabaseSpec.scala
@@ -11,7 +11,7 @@ object MongoDatabaseSpec extends ZIOSpecDefault {
       MongoDatabaseTest.withRandomName { db =>
         for {
           _           <- db.createCollection("test-collection")
-          collections <- db.listCollections().first().map(_.flatMap(_.get("name")))
+          collections <- db.listCollections().runHead.map(_.flatMap(_.get("name")))
         } yield assertTrue(collections.contains(BsonString("test-collection")))
       }
     },

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/MongoCollection.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/MongoCollection.scala
@@ -25,6 +25,7 @@ import io.github.zeal18.zio.mongodb.driver.indexes.IndexOptions
 import io.github.zeal18.zio.mongodb.driver.model.*
 import io.github.zeal18.zio.mongodb.driver.model.bulk.BulkWrite
 import io.github.zeal18.zio.mongodb.driver.query.*
+import io.github.zeal18.zio.mongodb.driver.reactivestreams.*
 import io.github.zeal18.zio.mongodb.driver.result.*
 import io.github.zeal18.zio.mongodb.driver.updates.Update
 import org.bson.codecs.configuration.CodecRegistries.*
@@ -1512,32 +1513,32 @@ object MongoCollection {
       Live[A](database, wrapped.withReadConcern(readConcern))
 
     override def estimatedDocumentCount(): Task[Long] =
-      wrapped.estimatedDocumentCount().getOne.map(identity[Long](_))
+      wrapped.estimatedDocumentCount().head.map(identity[Long](_))
 
     override def estimatedDocumentCount(options: EstimatedDocumentCountOptions): Task[Long] =
-      wrapped.estimatedDocumentCount(options.toJava).getOne.map(identity[Long](_))
+      wrapped.estimatedDocumentCount(options.toJava).head.map(identity[Long](_))
 
     override def countDocuments(): Task[Long] =
-      wrapped.countDocuments().getOne.map(identity[Long](_))
+      wrapped.countDocuments().head.map(identity[Long](_))
 
     override def countDocuments(filter: Filter): Task[Long] =
-      wrapped.countDocuments(filter).getOne.map(identity[Long](_))
+      wrapped.countDocuments(filter).head.map(identity[Long](_))
 
     override def countDocuments(filter: Filter, options: CountOptions): Task[Long] =
-      wrapped.countDocuments(filter, options.toJava).getOne.map(identity[Long](_))
+      wrapped.countDocuments(filter, options.toJava).head.map(identity[Long](_))
 
     override def countDocuments(clientSession: ClientSession): Task[Long] =
-      wrapped.countDocuments(clientSession).getOne.map(identity[Long](_))
+      wrapped.countDocuments(clientSession).head.map(identity[Long](_))
 
     override def countDocuments(clientSession: ClientSession, filter: Filter): Task[Long] =
-      wrapped.countDocuments(clientSession, filter).getOne.map(identity[Long](_))
+      wrapped.countDocuments(clientSession, filter).head.map(identity[Long](_))
 
     override def countDocuments(
       clientSession: ClientSession,
       filter: Filter,
       options: CountOptions,
     ): Task[Long] =
-      wrapped.countDocuments(clientSession, filter, options.toJava).getOne.map(identity[Long](_))
+      wrapped.countDocuments(clientSession, filter, options.toJava).head.map(identity[Long](_))
 
     override def distinct(fieldName: String): DistinctQuery[A] =
       DistinctQuery(wrapped.distinct(fieldName, documentClass))
@@ -1579,115 +1580,115 @@ object MongoCollection {
       )
 
     override def bulkWrite(requests: Seq[BulkWrite[A]]): Task[BulkWriteResult] =
-      wrapped.bulkWrite(requests.map(_.toJava).asJava).getOne
+      wrapped.bulkWrite(requests.map(_.toJava).asJava).head
 
     override def bulkWrite(
       requests: Seq[BulkWrite[A]],
       options: BulkWriteOptions,
     ): Task[BulkWriteResult] =
-      wrapped.bulkWrite(requests.map(_.toJava).asJava, options.toJava).getOne
+      wrapped.bulkWrite(requests.map(_.toJava).asJava, options.toJava).head
 
     override def bulkWrite(
       clientSession: ClientSession,
       requests: Seq[BulkWrite[A]],
     ): Task[BulkWriteResult] =
-      wrapped.bulkWrite(clientSession, requests.map(_.toJava).asJava).getOne
+      wrapped.bulkWrite(clientSession, requests.map(_.toJava).asJava).head
 
     override def bulkWrite(
       clientSession: ClientSession,
       requests: Seq[BulkWrite[A]],
       options: BulkWriteOptions,
     ): Task[BulkWriteResult] =
-      wrapped.bulkWrite(clientSession, requests.map(_.toJava).asJava, options.toJava).getOne
+      wrapped.bulkWrite(clientSession, requests.map(_.toJava).asJava, options.toJava).head
 
-    override def insertOne(document: A): Task[InsertOneResult] = wrapped.insertOne(document).getOne
+    override def insertOne(document: A): Task[InsertOneResult] = wrapped.insertOne(document).head
 
     override def insertOne(document: A, options: InsertOneOptions): Task[InsertOneResult] =
-      wrapped.insertOne(document, options.toJava).getOne
+      wrapped.insertOne(document, options.toJava).head
 
     override def insertOne(
       clientSession: ClientSession,
       document: A,
     ): Task[InsertOneResult] =
-      wrapped.insertOne(clientSession, document).getOne
+      wrapped.insertOne(clientSession, document).head
 
     override def insertOne(
       clientSession: ClientSession,
       document: A,
       options: InsertOneOptions,
     ): Task[InsertOneResult] =
-      wrapped.insertOne(clientSession, document, options.toJava).getOne
+      wrapped.insertOne(clientSession, document, options.toJava).head
 
     override def insertMany(documents: Seq[? <: A]): Task[InsertManyResult] =
-      wrapped.insertMany(documents.asJava).getOne
+      wrapped.insertMany(documents.asJava).head
 
     override def insertMany(
       documents: Seq[? <: A],
       options: InsertManyOptions,
     ): Task[InsertManyResult] =
-      wrapped.insertMany(documents.asJava, options.toJava).getOne
+      wrapped.insertMany(documents.asJava, options.toJava).head
 
     override def insertMany(
       clientSession: ClientSession,
       documents: Seq[? <: A],
     ): Task[InsertManyResult] =
-      wrapped.insertMany(clientSession, documents.asJava).getOne
+      wrapped.insertMany(clientSession, documents.asJava).head
 
     override def insertMany(
       clientSession: ClientSession,
       documents: Seq[? <: A],
       options: InsertManyOptions,
     ): Task[InsertManyResult] =
-      wrapped.insertMany(clientSession, documents.asJava, options.toJava).getOne
+      wrapped.insertMany(clientSession, documents.asJava, options.toJava).head
 
     override def deleteOne(filter: Filter): Task[DeleteResult] =
-      wrapped.deleteOne(filter).getOne
+      wrapped.deleteOne(filter).head
 
     override def deleteOne(filter: Filter, options: DeleteOptions): Task[DeleteResult] =
-      wrapped.deleteOne(filter, options.toJava).getOne
+      wrapped.deleteOne(filter, options.toJava).head
 
     override def deleteOne(clientSession: ClientSession, filter: Filter): Task[DeleteResult] =
-      wrapped.deleteOne(clientSession, filter).getOne
+      wrapped.deleteOne(clientSession, filter).head
 
     override def deleteOne(
       clientSession: ClientSession,
       filter: Filter,
       options: DeleteOptions,
     ): Task[DeleteResult] =
-      wrapped.deleteOne(clientSession, filter, options.toJava).getOne
+      wrapped.deleteOne(clientSession, filter, options.toJava).head
 
     override def deleteMany(filter: Filter): Task[DeleteResult] =
-      wrapped.deleteMany(filter).getOne
+      wrapped.deleteMany(filter).head
 
     override def deleteMany(filter: Filter, options: DeleteOptions): Task[DeleteResult] =
-      wrapped.deleteMany(filter, options.toJava).getOne
+      wrapped.deleteMany(filter, options.toJava).head
 
     override def deleteMany(clientSession: ClientSession, filter: Filter): Task[DeleteResult] =
-      wrapped.deleteMany(clientSession, filter).getOne
+      wrapped.deleteMany(clientSession, filter).head
 
     override def deleteMany(
       clientSession: ClientSession,
       filter: Filter,
       options: DeleteOptions,
     ): Task[DeleteResult] =
-      wrapped.deleteMany(clientSession, filter, options.toJava).getOne
+      wrapped.deleteMany(clientSession, filter, options.toJava).head
 
     override def replaceOne(filter: Filter, replacement: A): Task[UpdateResult] =
-      wrapped.replaceOne(filter, replacement).getOne
+      wrapped.replaceOne(filter, replacement).head
 
     override def replaceOne(
       clientSession: ClientSession,
       filter: Filter,
       replacement: A,
     ): Task[UpdateResult] =
-      wrapped.replaceOne(clientSession, filter, replacement).getOne
+      wrapped.replaceOne(clientSession, filter, replacement).head
 
     override def replaceOne(
       filter: Filter,
       replacement: A,
       options: ReplaceOptions,
     ): Task[UpdateResult] =
-      wrapped.replaceOne(filter, replacement, options.toJava).getOne
+      wrapped.replaceOne(filter, replacement, options.toJava).head
 
     override def replaceOne(
       clientSession: ClientSession,
@@ -1695,24 +1696,24 @@ object MongoCollection {
       replacement: A,
       options: ReplaceOptions,
     ): Task[UpdateResult] =
-      wrapped.replaceOne(clientSession, filter, replacement, options.toJava).getOne
+      wrapped.replaceOne(clientSession, filter, replacement, options.toJava).head
 
     override def updateOne(filter: Filter, update: Update): Task[UpdateResult] =
-      wrapped.updateOne(filter, update).getOne
+      wrapped.updateOne(filter, update).head
 
     override def updateOne(
       filter: Filter,
       update: Update,
       options: UpdateOptions,
     ): Task[UpdateResult] =
-      wrapped.updateOne(filter, update, options.toJava).getOne
+      wrapped.updateOne(filter, update, options.toJava).head
 
     override def updateOne(
       clientSession: ClientSession,
       filter: Filter,
       update: Update,
     ): Task[UpdateResult] =
-      wrapped.updateOne(clientSession, filter, update).getOne
+      wrapped.updateOne(clientSession, filter, update).head
 
     override def updateOne(
       clientSession: ClientSession,
@@ -1720,24 +1721,24 @@ object MongoCollection {
       update: Update,
       options: UpdateOptions,
     ): Task[UpdateResult] =
-      wrapped.updateOne(clientSession, filter, update, options.toJava).getOne
+      wrapped.updateOne(clientSession, filter, update, options.toJava).head
 
     override def updateOne(filter: Filter, update: Seq[Update]): Task[UpdateResult] =
-      wrapped.updateOne(filter, update.asJava).getOne
+      wrapped.updateOne(filter, update.asJava).head
 
     override def updateOne(
       filter: Filter,
       update: Seq[Update],
       options: UpdateOptions,
     ): Task[UpdateResult] =
-      wrapped.updateOne(filter, update.asJava, options.toJava).getOne
+      wrapped.updateOne(filter, update.asJava, options.toJava).head
 
     override def updateOne(
       clientSession: ClientSession,
       filter: Filter,
       update: Seq[Update],
     ): Task[UpdateResult] =
-      wrapped.updateOne(clientSession, filter, update.asJava).getOne
+      wrapped.updateOne(clientSession, filter, update.asJava).head
 
     override def updateOne(
       clientSession: ClientSession,
@@ -1745,24 +1746,24 @@ object MongoCollection {
       update: Seq[Update],
       options: UpdateOptions,
     ): Task[UpdateResult] =
-      wrapped.updateOne(clientSession, filter, update.asJava, options.toJava).getOne
+      wrapped.updateOne(clientSession, filter, update.asJava, options.toJava).head
 
     override def updateMany(filter: Filter, update: Update): Task[UpdateResult] =
-      wrapped.updateMany(filter, update).getOne
+      wrapped.updateMany(filter, update).head
 
     override def updateMany(
       filter: Filter,
       update: Update,
       options: UpdateOptions,
     ): Task[UpdateResult] =
-      wrapped.updateMany(filter, update, options.toJava).getOne
+      wrapped.updateMany(filter, update, options.toJava).head
 
     override def updateMany(
       clientSession: ClientSession,
       filter: Filter,
       update: Update,
     ): Task[UpdateResult] =
-      wrapped.updateMany(clientSession, filter, update).getOne
+      wrapped.updateMany(clientSession, filter, update).head
 
     override def updateMany(
       clientSession: ClientSession,
@@ -1770,24 +1771,24 @@ object MongoCollection {
       update: Update,
       options: UpdateOptions,
     ): Task[UpdateResult] =
-      wrapped.updateMany(clientSession, filter, update, options.toJava).getOne
+      wrapped.updateMany(clientSession, filter, update, options.toJava).head
 
     override def updateMany(filter: Filter, update: Seq[Update]): Task[UpdateResult] =
-      wrapped.updateMany(filter, update.asJava).getOne
+      wrapped.updateMany(filter, update.asJava).head
 
     override def updateMany(
       filter: Filter,
       update: Seq[Update],
       options: UpdateOptions,
     ): Task[UpdateResult] =
-      wrapped.updateMany(filter, update.asJava, options.toJava).getOne
+      wrapped.updateMany(filter, update.asJava, options.toJava).head
 
     override def updateMany(
       clientSession: ClientSession,
       filter: Filter,
       update: Seq[Update],
     ): Task[UpdateResult] =
-      wrapped.updateMany(clientSession, filter, update.asJava).getOne
+      wrapped.updateMany(clientSession, filter, update.asJava).head
 
     override def updateMany(
       clientSession: ClientSession,
@@ -1795,43 +1796,43 @@ object MongoCollection {
       update: Seq[Update],
       options: UpdateOptions,
     ): Task[UpdateResult] =
-      wrapped.updateMany(clientSession, filter, update.asJava, options.toJava).getOne
+      wrapped.updateMany(clientSession, filter, update.asJava, options.toJava).head
 
     override def findOneAndDelete(filter: Filter): Task[Option[A]] =
-      wrapped.findOneAndDelete(filter).getOneOpt
+      wrapped.findOneAndDelete(filter).headOption
 
     override def findOneAndDelete(
       filter: Filter,
       options: FindOneAndDeleteOptions,
     ): Task[Option[A]] =
-      wrapped.findOneAndDelete(filter, options.toJava).getOneOpt
+      wrapped.findOneAndDelete(filter, options.toJava).headOption
 
     override def findOneAndDelete(clientSession: ClientSession, filter: Filter): Task[Option[A]] =
-      wrapped.findOneAndDelete(clientSession, filter).getOneOpt
+      wrapped.findOneAndDelete(clientSession, filter).headOption
 
     override def findOneAndDelete(
       clientSession: ClientSession,
       filter: Filter,
       options: FindOneAndDeleteOptions,
     ): Task[Option[A]] =
-      wrapped.findOneAndDelete(clientSession, filter, options.toJava).getOneOpt
+      wrapped.findOneAndDelete(clientSession, filter, options.toJava).headOption
 
     override def findOneAndReplace(filter: Filter, replacement: A): Task[Option[A]] =
-      wrapped.findOneAndReplace(filter, replacement).getOneOpt
+      wrapped.findOneAndReplace(filter, replacement).headOption
 
     override def findOneAndReplace(
       filter: Filter,
       replacement: A,
       options: FindOneAndReplaceOptions,
     ): Task[Option[A]] =
-      wrapped.findOneAndReplace(filter, replacement, options.toJava).getOneOpt
+      wrapped.findOneAndReplace(filter, replacement, options.toJava).headOption
 
     override def findOneAndReplace(
       clientSession: ClientSession,
       filter: Filter,
       replacement: A,
     ): Task[Option[A]] =
-      wrapped.findOneAndReplace(clientSession, filter, replacement).getOneOpt
+      wrapped.findOneAndReplace(clientSession, filter, replacement).headOption
 
     override def findOneAndReplace(
       clientSession: ClientSession,
@@ -1839,24 +1840,24 @@ object MongoCollection {
       replacement: A,
       options: FindOneAndReplaceOptions,
     ): Task[Option[A]] =
-      wrapped.findOneAndReplace(clientSession, filter, replacement, options.toJava).getOneOpt
+      wrapped.findOneAndReplace(clientSession, filter, replacement, options.toJava).headOption
 
     override def findOneAndUpdate(filter: Filter, update: Update): Task[Option[A]] =
-      wrapped.findOneAndUpdate(filter, update).getOneOpt
+      wrapped.findOneAndUpdate(filter, update).headOption
 
     override def findOneAndUpdate(
       filter: Filter,
       update: Update,
       options: FindOneAndUpdateOptions,
     ): Task[Option[A]] =
-      wrapped.findOneAndUpdate(filter, update, options.toJava).getOneOpt
+      wrapped.findOneAndUpdate(filter, update, options.toJava).headOption
 
     override def findOneAndUpdate(
       clientSession: ClientSession,
       filter: Filter,
       update: Update,
     ): Task[Option[A]] =
-      wrapped.findOneAndUpdate(clientSession, filter, update).getOneOpt
+      wrapped.findOneAndUpdate(clientSession, filter, update).headOption
 
     override def findOneAndUpdate(
       clientSession: ClientSession,
@@ -1864,24 +1865,24 @@ object MongoCollection {
       update: Update,
       options: FindOneAndUpdateOptions,
     ): Task[Option[A]] =
-      wrapped.findOneAndUpdate(clientSession, filter, update, options.toJava).getOneOpt
+      wrapped.findOneAndUpdate(clientSession, filter, update, options.toJava).headOption
 
     override def findOneAndUpdate(filter: Filter, update: Seq[Update]): Task[Option[A]] =
-      wrapped.findOneAndUpdate(filter, update.asJava).getOneOpt
+      wrapped.findOneAndUpdate(filter, update.asJava).headOption
 
     override def findOneAndUpdate(
       filter: Filter,
       update: Seq[Update],
       options: FindOneAndUpdateOptions,
     ): Task[Option[A]] =
-      wrapped.findOneAndUpdate(filter, update.asJava, options.toJava).getOneOpt
+      wrapped.findOneAndUpdate(filter, update.asJava, options.toJava).headOption
 
     override def findOneAndUpdate(
       clientSession: ClientSession,
       filter: Filter,
       update: Seq[Update],
     ): Task[Option[A]] =
-      wrapped.findOneAndUpdate(clientSession, filter, update.asJava).getOneOpt
+      wrapped.findOneAndUpdate(clientSession, filter, update.asJava).headOption
 
     override def findOneAndUpdate(
       clientSession: ClientSession,
@@ -1889,32 +1890,32 @@ object MongoCollection {
       update: Seq[Update],
       options: FindOneAndUpdateOptions,
     ): Task[Option[A]] =
-      wrapped.findOneAndUpdate(clientSession, filter, update.asJava, options.toJava).getOneOpt
+      wrapped.findOneAndUpdate(clientSession, filter, update.asJava, options.toJava).headOption
 
-    override def drop(): Task[Unit] = wrapped.drop().getOneOpt.unit
+    override def drop(): Task[Unit] = wrapped.drop().headOption.unit
 
     override def drop(clientSession: ClientSession): Task[Unit] =
-      wrapped.drop(clientSession).getOneOpt.unit
+      wrapped.drop(clientSession).headOption.unit
 
-    override def createIndex(key: IndexKey): Task[String] = wrapped.createIndex(key).getOne
+    override def createIndex(key: IndexKey): Task[String] = wrapped.createIndex(key).head
 
     override def createIndex(key: IndexKey, options: IndexOptions): Task[String] =
-      wrapped.createIndex(key, options.toJava).getOne
+      wrapped.createIndex(key, options.toJava).head
 
     override def createIndex(clientSession: ClientSession, key: IndexKey): Task[String] =
-      wrapped.createIndex(clientSession, key).getOne
+      wrapped.createIndex(clientSession, key).head
 
     override def createIndex(
       clientSession: ClientSession,
       key: IndexKey,
       options: IndexOptions,
     ): Task[String] =
-      wrapped.createIndex(clientSession, key, options.toJava).getOne
+      wrapped.createIndex(clientSession, key, options.toJava).head
 
     override def createIndexes(indexes: Index*): Task[Chunk[String]] = {
       val models = indexes.map(_.toJava).asJava
 
-      wrapped.createIndexes(models).stream.runCollect
+      wrapped.createIndexes(models).toChunk
     }
 
     override def createIndexes(
@@ -1923,7 +1924,7 @@ object MongoCollection {
     ): Task[Chunk[String]] = {
       val models = indexes.map(_.toJava).asJava
 
-      wrapped.createIndexes(models, createIndexOptions.toJava).stream.runCollect
+      wrapped.createIndexes(models, createIndexOptions.toJava).toChunk
     }
 
     override def createIndexes(
@@ -1932,7 +1933,7 @@ object MongoCollection {
     ): Task[Chunk[String]] = {
       val models = indexes.map(_.toJava).asJava
 
-      wrapped.createIndexes(clientSession, models).stream.runCollect
+      wrapped.createIndexes(clientSession, models).toChunk
     }
 
     override def createIndexes(
@@ -1942,7 +1943,7 @@ object MongoCollection {
     ): Task[Chunk[String]] = {
       val models = indexes.map(_.toJava).asJava
 
-      wrapped.createIndexes(clientSession, models, createIndexOptions.toJava).stream.runCollect
+      wrapped.createIndexes(clientSession, models, createIndexOptions.toJava).toChunk
     }
 
     override def listIndexes(): ListIndexesQuery[Document] =
@@ -1952,72 +1953,75 @@ object MongoCollection {
       ListIndexesQuery(wrapped.listIndexes(clientSession, implicitly[ClassTag[Document]]))
 
     override def dropIndex(indexName: String): Task[Unit] =
-      wrapped.dropIndex(indexName).getOneOpt.unit
+      wrapped.dropIndex(indexName).headOption.unit
 
     override def dropIndex(indexName: String, dropIndexOptions: DropIndexOptions): Task[Unit] =
-      wrapped.dropIndex(indexName, dropIndexOptions.toJava).getOneOpt.unit
+      wrapped.dropIndex(indexName, dropIndexOptions.toJava).headOption.unit
 
     override def dropIndex(keys: IndexKey): Task[Unit] =
-      wrapped.dropIndex(keys).getOneOpt.unit
+      wrapped.dropIndex(keys).headOption.unit
 
     override def dropIndex(keys: IndexKey, dropIndexOptions: DropIndexOptions): Task[Unit] =
-      wrapped.dropIndex(keys, dropIndexOptions.toJava).getOneOpt.unit
+      wrapped.dropIndex(keys, dropIndexOptions.toJava).headOption.unit
 
     override def dropIndex(clientSession: ClientSession, indexName: String): Task[Unit] =
-      wrapped.dropIndex(clientSession, indexName).getOneOpt.unit
+      wrapped.dropIndex(clientSession, indexName).headOption.unit
 
     override def dropIndex(
       clientSession: ClientSession,
       indexName: String,
       dropIndexOptions: DropIndexOptions,
     ): Task[Unit] =
-      wrapped.dropIndex(clientSession, indexName, dropIndexOptions.toJava).getOneOpt.unit
+      wrapped.dropIndex(clientSession, indexName, dropIndexOptions.toJava).headOption.unit
 
     override def dropIndex(clientSession: ClientSession, keys: IndexKey): Task[Unit] =
-      wrapped.dropIndex(clientSession, keys).getOneOpt.unit
+      wrapped.dropIndex(clientSession, keys).headOption.unit
 
     override def dropIndex(
       clientSession: ClientSession,
       keys: IndexKey,
       dropIndexOptions: DropIndexOptions,
     ): Task[Unit] =
-      wrapped.dropIndex(clientSession, keys, dropIndexOptions.toJava).getOneOpt.unit
+      wrapped.dropIndex(clientSession, keys, dropIndexOptions.toJava).headOption.unit
 
-    override def dropIndexes(): Task[Unit] = wrapped.dropIndexes().getOneOpt.unit
+    override def dropIndexes(): Task[Unit] = wrapped.dropIndexes().headOption.unit
 
     override def dropIndexes(dropIndexOptions: DropIndexOptions): Task[Unit] =
-      wrapped.dropIndexes(dropIndexOptions.toJava).getOneOpt.unit
+      wrapped.dropIndexes(dropIndexOptions.toJava).headOption.unit
 
     override def dropIndexes(clientSession: ClientSession): Task[Unit] =
-      wrapped.dropIndexes(clientSession).getOneOpt.unit
+      wrapped.dropIndexes(clientSession).headOption.unit
 
     override def dropIndexes(
       clientSession: ClientSession,
       dropIndexOptions: DropIndexOptions,
     ): Task[Unit] =
-      wrapped.dropIndexes(clientSession, dropIndexOptions.toJava).getOneOpt.unit
+      wrapped.dropIndexes(clientSession, dropIndexOptions.toJava).headOption.unit
 
     override def renameCollection(newCollectionNamespace: MongoNamespace): Task[Unit] =
-      wrapped.renameCollection(newCollectionNamespace).getOneOpt.unit
+      wrapped.renameCollection(newCollectionNamespace).headOption.unit
 
     override def renameCollection(
       newCollectionNamespace: MongoNamespace,
       options: RenameCollectionOptions,
     ): Task[Unit] =
-      wrapped.renameCollection(newCollectionNamespace, options.toJava).getOneOpt.unit
+      wrapped.renameCollection(newCollectionNamespace, options.toJava).headOption.unit
 
     override def renameCollection(
       clientSession: ClientSession,
       newCollectionNamespace: MongoNamespace,
     ): Task[Unit] =
-      wrapped.renameCollection(clientSession, newCollectionNamespace).getOneOpt.unit
+      wrapped.renameCollection(clientSession, newCollectionNamespace).headOption.unit
 
     override def renameCollection(
       clientSession: ClientSession,
       newCollectionNamespace: MongoNamespace,
       options: RenameCollectionOptions,
     ): Task[Unit] =
-      wrapped.renameCollection(clientSession, newCollectionNamespace, options.toJava).getOneOpt.unit
+      wrapped
+        .renameCollection(clientSession, newCollectionNamespace, options.toJava)
+        .headOption
+        .unit
 
     override def watch(): ChangeStreamQuery[A] =
       ChangeStreamQuery(wrapped.watch(documentClass))

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/package.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/package.scala
@@ -6,18 +6,8 @@ import io.github.zeal18.zio.mongodb.bson.BsonDocument
 import org.bson.BsonDocumentReader
 import org.bson.codecs.DecoderContext
 import org.bson.codecs.DocumentCodec
-import org.reactivestreams.Publisher
-import zio.Task
-import zio.interop.reactivestreams.*
-import zio.stream.ZStream
 
 package object driver {
-  implicit class PublisherOps[A](private val publisher: Publisher[A]) extends AnyVal {
-    def stream: ZStream[Any, Throwable, A] = publisher.toZIOStream()
-    def getOneOpt: Task[Option[A]]         = publisher.toZIOStream(qSize = 2).runHead
-    def getOne: Task[A] =
-      getOneOpt.someOrFail(new IllegalStateException("Expected one value but received nothing"))
-  }
 
   /** An immutable Document implementation.
     *

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/query/ChangeStreamQuery.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/query/ChangeStreamQuery.scala
@@ -8,12 +8,12 @@ import com.mongodb.reactivestreams.client.ChangeStreamPublisher
 import io.github.zeal18.zio.mongodb.bson.BsonDocument
 import io.github.zeal18.zio.mongodb.bson.BsonTimestamp
 import io.github.zeal18.zio.mongodb.bson.BsonValue
-import io.github.zeal18.zio.mongodb.driver.*
 import io.github.zeal18.zio.mongodb.driver.model.Collation
 import io.github.zeal18.zio.mongodb.driver.model.changestream.ChangeStreamDocument
 import io.github.zeal18.zio.mongodb.driver.model.changestream.FullDocument
+import io.github.zeal18.zio.mongodb.driver.reactivestreams.*
+import org.reactivestreams.Publisher
 import zio.Task
-import zio.stream.ZStream
 
 /** Observable for change streams.
   *
@@ -144,11 +144,7 @@ case class ChangeStreamQuery[TResult](private val wrapped: ChangeStreamPublisher
   // def withDocumentClass[T](clazz: Class[T]): Observable[T] =
   //   wrapped.withDocumentClass(clazz).toObservable()
 
-  /** Helper to return a single observable limited to the first result.
-    *
-    * @return a single observable which will the first result.
-    */
-  def first(): Task[Option[ChangeStreamDocument[TResult]]] = wrapped.first().getOneOpt
+  override def runHead: Task[Option[ChangeStreamDocument[TResult]]] = wrapped.first().headOption
 
-  override def execute: ZStream[Any, Throwable, ChangeStreamDocument[TResult]] = wrapped.stream
+  override def run: Publisher[ChangeStreamDocument[TResult]] = wrapped
 }

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/query/DistinctQuery.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/query/DistinctQuery.scala
@@ -6,11 +6,11 @@ import scala.concurrent.duration.Duration
 
 import com.mongodb.reactivestreams.client.DistinctPublisher
 import io.github.zeal18.zio.mongodb.bson.BsonValue
-import io.github.zeal18.zio.mongodb.driver.*
 import io.github.zeal18.zio.mongodb.driver.filters.Filter
 import io.github.zeal18.zio.mongodb.driver.model.Collation
+import io.github.zeal18.zio.mongodb.driver.reactivestreams.*
+import org.reactivestreams.Publisher
 import zio.Task
-import zio.stream.ZStream
 
 /** Observable for distinct
   *
@@ -86,11 +86,7 @@ case class DistinctQuery[TResult](private val wrapped: DistinctPublisher[TResult
     this
   }
 
-  /** Helper to return a single observable limited to the first result.
-    *
-    * @return a single observable which will the first result.
-    */
-  def first(): Task[Option[TResult]] = wrapped.first().getOneOpt
+  override def runHead: Task[Option[TResult]] = wrapped.first().headOption
 
-  override def execute: ZStream[Any, Throwable, TResult] = wrapped.stream
+  override def run: Publisher[TResult] = wrapped
 }

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/query/ListCollectionsQuery.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/query/ListCollectionsQuery.scala
@@ -7,9 +7,9 @@ import scala.concurrent.duration.Duration
 import com.mongodb.reactivestreams.client.ListCollectionsPublisher
 import io.github.zeal18.zio.mongodb.bson.BsonValue
 import io.github.zeal18.zio.mongodb.bson.conversions.Bson
-import io.github.zeal18.zio.mongodb.driver.*
+import io.github.zeal18.zio.mongodb.driver.reactivestreams.*
+import org.reactivestreams.Publisher
 import zio.Task
-import zio.stream.ZStream
 
 /** Observable interface for ListCollections
   *
@@ -73,11 +73,7 @@ case class ListCollectionsQuery[TResult](wrapped: ListCollectionsPublisher[TResu
     this
   }
 
-  /** Helper to return a single observable limited to the first result.
-    *
-    * @return a single observable which will the first result.
-    */
-  def first(): Task[Option[TResult]] = wrapped.first().getOneOpt
+  override def runHead: Task[Option[TResult]] = wrapped.first().headOption
 
-  override def execute: ZStream[Any, Throwable, TResult] = wrapped.stream
+  override def run: Publisher[TResult] = wrapped
 }

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/query/ListDatabasesQuery.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/query/ListDatabasesQuery.scala
@@ -7,9 +7,9 @@ import scala.concurrent.duration.Duration
 import com.mongodb.reactivestreams.client.ListDatabasesPublisher
 import io.github.zeal18.zio.mongodb.bson.BsonValue
 import io.github.zeal18.zio.mongodb.bson.conversions.Bson
-import io.github.zeal18.zio.mongodb.driver.*
+import io.github.zeal18.zio.mongodb.driver.reactivestreams.*
+import org.reactivestreams.Publisher
 import zio.Task
-import zio.stream.ZStream
 
 /** Observable interface for ListDatabases.
   *
@@ -97,11 +97,7 @@ case class ListDatabasesQuery[TResult](wrapped: ListDatabasesPublisher[TResult])
     this
   }
 
-  /** Helper to return a single observable limited to the first result.
-    *
-    * @return a single observable which will the first result.
-    */
-  def first(): Task[Option[TResult]] = wrapped.first().getOneOpt
+  override def runHead: Task[Option[TResult]] = wrapped.first().headOption
 
-  override def execute: ZStream[Any, Throwable, TResult] = wrapped.stream
+  override def run: Publisher[TResult] = wrapped
 }

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/query/ListIndexesQuery.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/query/ListIndexesQuery.scala
@@ -6,9 +6,9 @@ import scala.concurrent.duration.Duration
 
 import com.mongodb.reactivestreams.client.ListIndexesPublisher
 import io.github.zeal18.zio.mongodb.bson.BsonValue
-import io.github.zeal18.zio.mongodb.driver.*
+import io.github.zeal18.zio.mongodb.driver.reactivestreams.*
+import org.reactivestreams.Publisher
 import zio.Task
-import zio.stream.ZStream
 
 /** Observable interface for ListIndexes.
   *
@@ -61,11 +61,7 @@ case class ListIndexesQuery[TResult](wrapped: ListIndexesPublisher[TResult])
     this
   }
 
-  /** Helper to return a single observable limited to the first result.
-    *
-    * @return a single observable which will the first result.
-    */
-  def first(): Task[Option[TResult]] = wrapped.first().getOneOpt
+  override def runHead: Task[Option[TResult]] = wrapped.first().headOption
 
-  override def execute: ZStream[Any, Throwable, TResult] = wrapped.stream
+  override def run: Publisher[TResult] = wrapped
 }

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/query/Query.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/query/Query.scala
@@ -1,7 +1,122 @@
 package io.github.zeal18.zio.mongodb.driver.query
 
+import io.github.zeal18.zio.mongodb.driver.reactivestreams.*
+import org.reactivestreams.Publisher
+import zio.Chunk
+import zio.Task
+import zio.interop.reactivestreams.*
 import zio.stream.ZStream
 
 trait Query[A] {
-  def execute: ZStream[Any, Throwable, A]
+  @deprecated("use runToZStream", "0.8.0")
+  def execute: ZStream[Any, Throwable, A] = runToZStream()
+
+  /** Runs query returning low level reactive Publisher
+    *
+    * It could be useful for dealing with special cases, otherwise it's recommended to use one of high level run* methods
+    *
+    * @see
+    *   [[runToZSTream]]
+    *   [[runToList]]
+    *   [[runToSeq]]
+    *   [[runToVector]]
+    *   [[runToSet]]
+    *   [[runToChunk]]
+    */
+  def run: Publisher[A]
+
+  /** Runs query to a ZStream
+    *
+    * Use this method for potentially big or unlimited queries
+    *
+    * @param qSize internal buffer size
+    *
+    * @see
+    *   [[runToList]]
+    *   [[runToSeq]]
+    *   [[runToVector]]
+    *   [[runToSet]]
+    *   [[runToChunk]]
+    */
+  def runToZStream(qSize: Int = 16): ZStream[Any, Throwable, A] = run.toZIOStream(qSize)
+
+  /** Runs query to a [[List]]
+    *
+    * NOTE: this method collects all data in memory, use it only for queries with limited capacity
+    *
+    * @see
+    *   [[runToZStream]]
+    *   [[runToSeq]]
+    *   [[runToVector]]
+    *   [[runToSet]]
+    *   [[runToChunk]]
+    */
+  def runToList: Task[List[A]] = run.toList
+
+  /** Runs query to a [[Seq]]
+    *
+    * NOTE: this method collects all data in memory, use it only for queries with limited capacity
+    *
+    * @see
+    *   [[runToZStream]]
+    *   [[runToList]]
+    *   [[runToVector]]
+    *   [[runToSet]]
+    *   [[runToChunk]]
+    */
+  def runToSeq: Task[Seq[A]] = run.toSeq
+
+  /** Runs query to a [[Vector]]
+    *
+    * NOTE: this method collects all data in memory, use it only for queries with limited capacity
+    *
+    * @see
+    *   [[runToZStream]]
+    *   [[runToList]]
+    *   [[runToSeq]]
+    *   [[runToSet]]
+    *   [[runToChunk]]
+    */
+  def runToVector: Task[Vector[A]] = run.toVector
+
+  /** Runs query to a [[Set]]
+    *
+    * NOTE: this method collects all data in memory, use it only for queries with limited capacity
+    *
+    * @see
+    *   [[runToZStream]]
+    *   [[runToList]]
+    *   [[runToSeq]]
+    *   [[runToVector]]
+    *   [[runToChunk]]
+    */
+  def runToSet: Task[Set[A]] = run.toSet
+
+  /** Runs query to a [[zio.Chunk]]
+    *
+    * NOTE: this method collects all data in memory, use it only for queries with limited capacity
+    *
+    * @see
+    *   [[runToZStream]]
+    *   [[runToList]]
+    *   [[runToSeq]]
+    *   [[runToVector]]
+    *   [[runToSet]]
+    */
+  def runToChunk: Task[Chunk[A]] = run.toChunk
+
+  /** Runs query returning the first element
+    *
+    * @see
+    *   [[runToZStream]]
+    *   [[runToList]]
+    *   [[runToSeq]]
+    *   [[runToVector]]
+    *   [[runToSet]]
+    *   [[runToChunk]]
+    */
+  def runHead: Task[Option[A]]
+
+  @deprecated("use runHead", "0.8.0")
+  def first: Task[Option[A]] = runHead
 }

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/EmptySubscriber.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/EmptySubscriber.scala
@@ -1,0 +1,69 @@
+package io.github.zeal18.zio.mongodb.driver.reactivestreams
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import zio.Scope
+import zio.Task
+import zio.UIO
+import zio.URIO
+import zio.ZIO
+
+private trait EmptySubscriber[A] extends Subscriber[A] {
+  def interrupt(): UIO[Unit]
+  def await(): Task[Unit]
+}
+
+private object EmptySubscriber {
+  def make[A]: URIO[Scope, EmptySubscriber[A]] = for {
+    subscriptionP <- ZIO.acquireRelease(
+      Promise.make[Throwable, Subscription],
+    )(
+      _.poll.flatMap(_.fold(ZIO.unit)(_.foldZIO(_ => ZIO.unit, sub => ZIO.succeed(sub.cancel())))),
+    )
+    promise <- Promise.make[Throwable, Unit]
+  } yield new EmptySubscriber[A] {
+
+    val isSubscribedOrInterrupted = new AtomicBoolean
+
+    override def interrupt(): UIO[Unit] = {
+      isSubscribedOrInterrupted.set(true)
+      promise.interrupt.unit
+    }
+
+    override def await(): Task[Unit] = promise.await
+
+    override def onSubscribe(s: Subscription): Unit =
+      if (s == null) // scalafix:ok
+        failNPE("s was null in onSubscribe")
+      else {
+        val shouldCancel = isSubscribedOrInterrupted.getAndSet(true)
+        if (shouldCancel) s.cancel()
+        else {
+          subscriptionP.unsafe.done(ZIO.succeed(s))
+          s.request(Int.MaxValue)
+        }
+      }
+
+    override def onNext(t: A): Unit = ()
+
+    override def onError(e: Throwable): Unit =
+      if (e == null) // scalafix:ok
+        failNPE("t was null in onError")
+      else
+        fail(e)
+
+    override def onComplete(): Unit =
+      promise.unsafe.done(ZIO.unit)
+
+    private def failNPE(msg: String) = {
+      val e = new NullPointerException(msg)
+      fail(e)
+      throw e // scalafix:ok
+    }
+
+    private def fail(e: Throwable): Unit =
+      promise.unsafe.done(ZIO.fail(e))
+  }
+}

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/IterableSubscriber.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/IterableSubscriber.scala
@@ -1,0 +1,79 @@
+package io.github.zeal18.zio.mongodb.driver.reactivestreams
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.collection.IterableFactory
+import scala.collection.mutable.Builder
+
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import zio.Scope
+import zio.Task
+import zio.UIO
+import zio.URIO
+import zio.ZIO
+
+private trait IterableSubscriber[A, I[B] <: Iterable[B], B] extends Subscriber[A] {
+  def interrupt(): UIO[Unit]
+  def await(): Task[I[A]]
+}
+
+private object IterableSubscriber {
+  def make[A, I[B] <: Iterable[B], B](
+    factory: IterableFactory[I],
+  ): URIO[Scope, IterableSubscriber[A, I, B]] = for {
+    subscriptionP <- ZIO.acquireRelease(
+      Promise.make[Throwable, Subscription],
+    )(
+      _.poll.flatMap(_.fold(ZIO.unit)(_.foldZIO(_ => ZIO.unit, sub => ZIO.succeed(sub.cancel())))),
+    )
+    promise <- Promise.make[Throwable, I[A]]
+  } yield new IterableSubscriber[A, I, B] {
+
+    val isSubscribedOrInterrupted           = new AtomicBoolean
+    val collectionBuilder: Builder[A, I[A]] = factory.newBuilder
+
+    override def interrupt(): UIO[Unit] = {
+      isSubscribedOrInterrupted.set(true)
+      promise.interrupt.unit
+    }
+
+    override def await(): Task[I[A]] = promise.await
+
+    override def onSubscribe(s: Subscription): Unit =
+      if (s == null) // scalafix:ok
+        failNPE("s was null in onSubscribe")
+      else {
+        val shouldCancel = isSubscribedOrInterrupted.getAndSet(true)
+        if (shouldCancel) s.cancel()
+        else {
+          subscriptionP.unsafe.done(ZIO.succeed(s))
+          s.request(Int.MaxValue)
+        }
+      }
+
+    override def onNext(t: A): Unit =
+      if (t == null) // scalafix:ok
+        failNPE("t was null in onNext")
+      else
+        collectionBuilder += t
+
+    override def onError(e: Throwable): Unit =
+      if (e == null) // scalafix:ok
+        failNPE("t was null in onError")
+      else
+        fail(e)
+
+    override def onComplete(): Unit =
+      promise.unsafe.done(ZIO.succeed(collectionBuilder.result()))
+
+    private def failNPE(msg: String) = {
+      val e = new NullPointerException(msg)
+      fail(e)
+      throw e // scalafix:ok
+    }
+
+    private def fail(e: Throwable): Unit =
+      promise.unsafe.done(ZIO.fail(e))
+  }
+}

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/Promise.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/Promise.scala
@@ -1,0 +1,253 @@
+package io.github.zeal18.zio.mongodb.driver.reactivestreams
+
+/* !!! copied from zio-core to be able to access the private api !!! */
+
+/*
+ * Copyright 2017-2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.concurrent.atomic.AtomicReference
+
+import io.github.zeal18.zio.mongodb.driver.reactivestreams.Promise.internal.*
+import zio.Cause
+import zio.Exit
+import zio.FiberId
+import zio.IO
+import zio.Trace
+import zio.UIO
+import zio.ZIO
+
+/** A promise represents an asynchronous variable, of [[zio.ZIO]] type, that can
+  * be set exactly once, with the ability for an arbitrary number of fibers to
+  * suspend (by calling `await`) and automatically resume when the variable is
+  * set.
+  *
+  * Promises can be used for building primitive actions whose completions require
+  * the coordinated action of multiple fibers, and for building higher-level
+  * concurrent or asynchronous structures.
+  * {{{
+  * for {
+  *   promise <- Promise.make[Nothing, Int]
+  *   _       <- promise.succeed(42).delay(1.second).fork
+  *   value   <- promise.await // Resumes when forked fiber completes promise
+  * } yield value
+  * }}}
+  */
+final private[reactivestreams] class Promise[E, A](
+  private val state: AtomicReference[Promise.internal.State[E, A]],
+  blockingOn: FiberId,
+) extends Serializable {
+
+  /** Retrieves the value of the promise, suspending the fiber running the action
+    * until the result is available.
+    */
+  def await(implicit trace: Trace): IO[E, A] =
+    ZIO.asyncInterrupt[Any, E, A](
+      k => {
+        var result = null.asInstanceOf[Either[UIO[Any], IO[E, A]]] // scalafix:ok
+        var retry  = true                                          // scalafix:ok
+
+        while (retry) { // scalafix:ok
+          val oldState = state.get
+
+          val newState = oldState match {
+            case Pending(joiners) =>
+              result = Left(interruptJoiner(k))
+
+              Pending(k :: joiners)
+            case s @ Done(value) =>
+              result = Right(value)
+
+              s
+          }
+
+          retry = !state.compareAndSet(oldState, newState)
+        }
+
+        result
+      },
+      blockingOn,
+    )
+
+  /** Kills the promise with the specified error, which will be propagated to all
+    * fibers waiting on the value of the promise.
+    */
+  def die(e: Throwable)(implicit trace: Trace): UIO[Boolean] = completeWith(ZIO.die(e))
+
+  /** Exits the promise with the specified exit, which will be propagated to all
+    * fibers waiting on the value of the promise.
+    */
+  def done(e: Exit[E, A])(implicit trace: Trace): UIO[Boolean] = completeWith(e)
+
+  /** Completes the promise with the specified effect. If the promise has already
+    * been completed, the method will produce false.
+    *
+    * Note that since the promise is completed with an effect, the effect will be
+    * evaluated each time the value of the promise is retrieved through
+    * combinators such as `await`, potentially producing different results if the
+    * effect produces different results on subsequent evaluations. In this case
+    * te meaning of the "exactly once" guarantee of `Promise` is that the promise
+    * can be completed with exactly one effect. For a version that completes the
+    * promise with the result of an effect see [[Promise.complete]].
+    */
+  def completeWith(io: IO[E, A])(implicit trace: Trace): UIO[Boolean] =
+    ZIO.succeed {
+      var action: () => Boolean = null.asInstanceOf[() => Boolean] // scalafix:ok
+      var retry                 = true                             // scalafix:ok
+
+      while (retry) { // scalafix:ok
+        val oldState = state.get
+
+        val newState = oldState match {
+          case Pending(joiners) =>
+            action = () => { joiners.foreach(_(io)); true }
+
+            Done(io)
+
+          case Done(_) =>
+            action = Promise.ConstFalse
+
+            oldState
+        }
+
+        retry = !state.compareAndSet(oldState, newState)
+      }
+
+      action()
+    }
+
+  /** Fails the promise with the specified error, which will be propagated to all
+    * fibers waiting on the value of the promise.
+    */
+  def fail(e: E)(implicit trace: Trace): UIO[Boolean] = completeWith(ZIO.fail(e))
+
+  /** Fails the promise with the specified cause, which will be propagated to all
+    * fibers waiting on the value of the promise.
+    */
+  def failCause(e: Cause[E])(implicit trace: Trace): UIO[Boolean] =
+    completeWith(ZIO.failCause(e))
+
+  /** Completes the promise with interruption. This will interrupt all fibers
+    * waiting on the value of the promise as by the fiber calling this method.
+    */
+  def interrupt(implicit trace: Trace): UIO[Boolean] =
+    ZIO.fiberId.flatMap(id => completeWith(ZIO.interruptAs(id)))
+
+  /** Completes the promise with interruption. This will interrupt all fibers
+    * waiting on the value of the promise as by the specified fiber.
+    */
+  def interruptAs(fiberId: FiberId)(implicit trace: Trace): UIO[Boolean] = completeWith(
+    ZIO.interruptAs(fiberId),
+  )
+
+  /** Checks for completion of this Promise. Produces true if this promise has
+    * already been completed with a value or an error and false otherwise.
+    */
+  def isDone(implicit trace: Trace): UIO[Boolean] =
+    ZIO.succeed(state.get() match {
+      case Done(_)    => true
+      case Pending(_) => false
+    })
+
+  /** Checks for completion of this Promise. Returns the result effect if this
+    * promise has already been completed or a `None` otherwise.
+    */
+  def poll(implicit trace: Trace): UIO[Option[IO[E, A]]] =
+    ZIO.succeed(state.get).flatMap {
+      case Pending(_) => Exit.Success(None)
+      case Done(io)   => Exit.Success(Some(io))
+    }
+
+  /** Fails the promise with the specified cause, which will be propagated to all
+    * fibers waiting on the value of the promise. No new stack trace is attached
+    * to the cause.
+    */
+  def refailCause(e: Cause[E])(implicit trace: Trace): UIO[Boolean] =
+    completeWith(ZIO.refailCause(e))
+
+  /** Completes the promise with the specified value.
+    */
+  def succeed(a: A)(implicit trace: Trace): UIO[Boolean] = completeWith(Exit.Success(a))
+
+  private def interruptJoiner(joiner: IO[E, A] => Any)(implicit trace: Trace): UIO[Any] =
+    ZIO.succeed {
+      var retry = true // scalafix:ok
+
+      while (retry) { // scalafix:ok
+        val oldState = state.get
+
+        val newState = oldState match {
+          case Pending(joiners) =>
+            Pending(joiners.filter(j => !j.eq(joiner)))
+
+          case Done(_) =>
+            oldState
+        }
+
+        retry = !state.compareAndSet(oldState, newState)
+      }
+    }
+
+  trait UnsafeAPI {
+    def done(io: IO[E, A]): Unit
+  }
+
+  @transient val unsafe: UnsafeAPI =
+    new UnsafeAPI {
+      def done(io: IO[E, A]): Unit = {
+        var retry: Boolean                 = true // scalafix:ok
+        var joiners: List[IO[E, A] => Any] = null // scalafix:ok
+
+        while (retry) { // scalafix:ok
+          val oldState = state.get
+
+          val newState = oldState match {
+            case Pending(js) =>
+              joiners = js
+              Done(io)
+            case _ => oldState
+          }
+
+          retry = !state.compareAndSet(oldState, newState)
+        }
+
+        if (joiners ne null) joiners.foreach(_(io)) // scalafix:ok
+      }
+    }
+}
+
+private[reactivestreams] object Promise {
+  private val ConstFalse: () => Boolean = () => false
+
+  object internal {
+    sealed abstract class State[E, A]                              extends Serializable with Product
+    final case class Pending[E, A](joiners: List[IO[E, A] => Any]) extends State[E, A]
+    final case class Done[E, A](value: IO[E, A])                   extends State[E, A]
+  }
+
+  /** Makes a new promise to be completed by the fiber creating the promise.
+    */
+  def make[E, A](implicit trace: Trace): UIO[Promise[E, A]] = ZIO.fiberIdWith(makeAs(_))
+
+  /** Makes a new promise to be completed by the fiber with the specified id.
+    */
+  def makeAs[E, A](fiberId: => FiberId)(implicit trace: Trace): UIO[Promise[E, A]] =
+    ZIO.succeed(unsafe.make(fiberId))
+
+  object unsafe {
+    def make[E, A](fiberId: FiberId): Promise[E, A] =
+      new Promise[E, A](new AtomicReference[State[E, A]](new internal.Pending[E, A](Nil)), fiberId)
+  }
+}

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/SingleElementSubscriber.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/SingleElementSubscriber.scala
@@ -1,0 +1,73 @@
+package io.github.zeal18.zio.mongodb.driver.reactivestreams
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import zio.Scope
+import zio.Task
+import zio.UIO
+import zio.URIO
+import zio.ZIO
+
+private trait SingleElementSubscriber[A] extends Subscriber[A] {
+  def interrupt(): UIO[Unit]
+  def await(): Task[Option[A]]
+}
+
+private object SingleElementSubscriber {
+  def make[A]: URIO[Scope, SingleElementSubscriber[A]] = for {
+    subscriptionP <- ZIO.acquireRelease(
+      Promise.make[Throwable, Subscription],
+    )(
+      _.poll.flatMap(_.fold(ZIO.unit)(_.foldZIO(_ => ZIO.unit, sub => ZIO.succeed(sub.cancel())))),
+    )
+    promise <- Promise.make[Throwable, Option[A]]
+  } yield new SingleElementSubscriber[A] {
+
+    val isSubscribedOrInterrupted = new AtomicBoolean
+
+    override def interrupt(): UIO[Unit] = {
+      isSubscribedOrInterrupted.set(true)
+      promise.interrupt.unit
+    }
+
+    override def await(): Task[Option[A]] = promise.await
+
+    override def onSubscribe(s: Subscription): Unit =
+      if (s == null) // scalafix:ok
+        failNPE("s was null in onSubscribe")
+      else {
+        val shouldCancel = isSubscribedOrInterrupted.getAndSet(true)
+        if (shouldCancel) s.cancel()
+        else {
+          subscriptionP.unsafe.done(ZIO.succeed(s))
+          s.request(Int.MaxValue)
+        }
+      }
+
+    override def onNext(t: A): Unit =
+      if (t == null) // scalafix:ok
+        failNPE("t was null in onNext")
+      else
+        promise.unsafe.done(ZIO.succeed(Some(t)))
+
+    override def onError(e: Throwable): Unit =
+      if (e == null) // scalafix:ok
+        failNPE("t was null in onError")
+      else
+        fail(e)
+
+    override def onComplete(): Unit =
+      promise.unsafe.done(ZIO.succeed(None))
+
+    private def failNPE(msg: String) = {
+      val e = new NullPointerException(msg)
+      fail(e)
+      throw e // scalafix:ok
+    }
+
+    private def fail(e: Throwable): Unit =
+      promise.unsafe.done(ZIO.fail(e))
+  }
+}

--- a/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/package.scala
+++ b/driver/src/main/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/package.scala
@@ -1,0 +1,52 @@
+package io.github.zeal18.zio.mongodb.driver
+
+import scala.collection.IterableFactory
+
+import org.reactivestreams.Publisher
+import zio.Chunk
+import zio.Task
+import zio.ZIO
+
+package object reactivestreams {
+  // implicit class PublisherVoidOps(private val publisher: Publisher[Void]) extends AnyVal {
+  //   def unit: Task[Unit] = ZIO.scoped(for {
+  //     subscriber <- EmptySubscriber.make[Void]
+  //     _ = publisher.subscribe(subscriber)
+
+  //     result <- subscriber.await().onInterrupt(ZIO.succeed(subscriber.interrupt()))
+  //   } yield result)
+  // }
+
+  implicit class PublisherOps[A](private val publisher: Publisher[A]) extends AnyVal {
+    def headOption: Task[Option[A]] = ZIO.scoped(for {
+      subscriber <- SingleElementSubscriber.make[A]
+      _ = publisher.subscribe(subscriber)
+
+      result <- subscriber.await().onInterrupt(ZIO.succeed(subscriber.interrupt()))
+    } yield result)
+
+    def head: Task[A] =
+      headOption.someOrFail(new IllegalStateException("Expected one value but received nothing"))
+
+    def unit: Task[Unit] = ZIO.scoped(for {
+      subscriber <- EmptySubscriber.make[A]
+      _ = publisher.subscribe(subscriber)
+
+      result <- subscriber.await().onInterrupt(ZIO.succeed(subscriber.interrupt()))
+    } yield result)
+
+    def toIterable[I[B] <: Iterable[B], B](factory: IterableFactory[I]): Task[I[A]] =
+      ZIO.scoped(for {
+        subscriber <- IterableSubscriber.make[A, I, B](factory)
+        _ = publisher.subscribe(subscriber)
+
+        result <- subscriber.await().onInterrupt(ZIO.succeed(subscriber.interrupt()))
+      } yield result)
+
+    def toList: Task[List[A]]     = toIterable(List)
+    def toSeq: Task[Seq[A]]       = toIterable(Seq)
+    def toVector: Task[Vector[A]] = toIterable(Vector)
+    def toSet: Task[Set[A]]       = toIterable(Set)
+    def toChunk: Task[Chunk[A]]   = toIterable(Chunk)
+  }
+}

--- a/driver/src/test/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/EmptySubscriberSpec.scala
+++ b/driver/src/test/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/EmptySubscriberSpec.scala
@@ -1,0 +1,170 @@
+package io.github.zeal18.zio.mongodb.driver.reactivestreams
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import org.reactivestreams.tck.TestEnvironment
+import org.reactivestreams.tck.TestEnvironment.ManualPublisher
+import zio.Chunk
+import zio.Exit
+import zio.Fiber
+import zio.Runtime
+import zio.Supervisor
+import zio.Task
+import zio.Trace
+import zio.UIO
+import zio.Unsafe
+import zio.ZEnvironment
+import zio.ZIO
+import zio.durationInt
+import zio.test.Assertion.*
+import zio.test.*
+
+object EmptySubscriberSpec extends ZIOSpecDefault {
+  override def spec =
+    suite("EmptySubscriberSpec")(
+      test("works with a well behaved `Publisher`") {
+        assertZIO(publish(seq, None))(succeeds(isUnit))
+      },
+      test("fails with an initially failed `Publisher`") {
+        assertZIO(publish(Chunk.empty, Some(e)))(fails(equalTo(e)))
+      },
+      test("returns Unit when completed without elements") {
+        withProbe(probe =>
+          assertZIO((for {
+            fiber  <- probe.unit.fork
+            _      <- ZIO.attemptBlockingInterrupt(probe.expectRequest())
+            _      <- ZIO.attempt(probe.sendCompletion())
+            result <- fiber.join
+          } yield result).exit)(
+            succeeds(isUnit),
+          ),
+        )
+      } @@ TestAspect.timeout(60.seconds),
+      test("does not fail a fiber on failing `Publisher`") {
+
+        val publisher = new Publisher[Int] {
+          override def subscribe(s: Subscriber[? >: Int]): Unit =
+            s.onSubscribe(
+              new Subscription {
+                override def request(n: Long): Unit = s.onError(new Throwable("boom!"))
+                override def cancel(): Unit         = ()
+              },
+            )
+        }
+
+        val supervisor =
+          new Supervisor[Boolean] {
+
+            override def onStart[R, E, A](
+              environment: ZEnvironment[R],
+              effect: ZIO[R, E, A],
+              parent: Option[Fiber.Runtime[Any, Any]],
+              fiber: Fiber.Runtime[E, A],
+            )(implicit unsafe: Unsafe): Unit = ()
+
+            override def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit
+              unsafe: Unsafe,
+            ): Unit =
+              if (value.isFailure) failedAFiber = true
+
+            @transient var failedAFiber = false // scalafix:ok
+
+            def value(implicit trace: Trace): UIO[Boolean] =
+              ZIO.succeed(failedAFiber)
+
+          }
+
+        for {
+          runtime <- Runtime.addSupervisor(supervisor).toRuntime
+          exit    <- runtime.run(publisher.unit.exit)
+          failed  <- supervisor.value
+        } yield assert(exit)(fails(anything)) && assert(failed)(isFalse)
+
+      },
+      test("cancels subscription when interrupted before subscription") {
+        val tst =
+          for {
+            subscriberP    <- Promise.make[Nothing, Subscriber[?]]
+            cancelledLatch <- Promise.make[Nothing, Unit]
+
+            subscription = new Subscription {
+              override def request(n: Long): Unit = ()
+              override def cancel(): Unit         = cancelledLatch.unsafe.done(ZIO.unit)
+            }
+            probe = new Publisher[Int] {
+              override def subscribe(subscriber: Subscriber[? >: Int]): Unit =
+                subscriberP.unsafe.done(ZIO.succeed(subscriber))
+            }
+
+            fiber      <- probe.unit.fork
+            subscriber <- subscriberP.await
+            _          <- fiber.interrupt
+            _          <- ZIO.succeed(subscriber.onSubscribe(subscription))
+            _          <- cancelledLatch.await
+          } yield ()
+
+        assertZIO(tst.exit)(succeeds(anything))
+      } @@ TestAspect.nonFlaky @@ TestAspect.timeout(60.seconds),
+      test("cancels subscription when interrupted after subscription") {
+        withProbe(probe =>
+          assertZIO((for {
+            fiber <- probe.unit.fork
+            _     <- ZIO.attemptBlockingInterrupt(probe.expectRequest())
+            _     <- fiber.interrupt
+            _     <- ZIO.attemptBlockingInterrupt(probe.expectCancelling())
+          } yield ()).exit)(
+            succeeds(isUnit),
+          ),
+        )
+      } @@ TestAspect.nonFlaky @@ TestAspect.timeout(60.seconds),
+      test("cancels subscription when interrupted during consumption") {
+        withProbe(probe =>
+          assertZIO((for {
+            fiber <- probe.unit.fork
+            _     <- ZIO.attemptBlockingInterrupt(probe.expectRequest())
+            _     <- ZIO.attempt((1 to 10).foreach(i => probe.sendNext(i)))
+            _     <- fiber.interrupt
+            _     <- ZIO.attemptBlockingInterrupt(probe.expectCancelling())
+          } yield ()).exit)(
+            succeeds(isUnit),
+          ),
+        )
+      } @@ TestAspect.nonFlaky @@ TestAspect.timeout(60.seconds),
+    )
+
+  val e: Throwable    = new RuntimeException("boom")
+  val seq: Chunk[Int] = Chunk.fromIterable(List.range(0, 100))
+
+  def withProbe[R, E0, E >: Throwable, A](f: ManualPublisher[Int] => ZIO[R, E, A]): ZIO[R, E, A] = {
+    val testEnv = new TestEnvironment(5000, 500)
+    val probe   = new ManualPublisher[Int](testEnv)
+    f(probe) <* ZIO.attempt(testEnv.verifyNoAsyncErrorsNoDelay())
+  }
+
+  def publish(seq: Chunk[Int], failure: Option[Throwable]): UIO[Exit[Throwable, Unit]] = {
+
+    def loop(probe: ManualPublisher[Int], remaining: Chunk[Int]): Task[Unit] =
+      for {
+        n <- ZIO.attemptBlockingInterrupt(probe.expectRequest())
+        split         = n.toInt
+        (nextN, tail) = remaining.splitAt(split)
+        _ <- ZIO.attempt(nextN.foreach(probe.sendNext))
+        _ <-
+          if (nextN.size < split)
+            ZIO.attempt(failure.fold(probe.sendCompletion())(probe.sendError))
+          else loop(probe, tail)
+      } yield ()
+
+    val faillable =
+      withProbe(probe =>
+        for {
+          fiber <- probe.unit.fork
+          _     <- loop(probe, seq)
+          r     <- fiber.join
+        } yield r,
+      )
+
+    faillable.exit
+  }
+}

--- a/driver/src/test/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/IterableSubscriberSpec.scala
+++ b/driver/src/test/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/IterableSubscriberSpec.scala
@@ -1,0 +1,161 @@
+package io.github.zeal18.zio.mongodb.driver.reactivestreams
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import org.reactivestreams.tck.TestEnvironment
+import org.reactivestreams.tck.TestEnvironment.ManualPublisher
+import zio.Chunk
+import zio.Exit
+import zio.Fiber
+import zio.Runtime
+import zio.Supervisor
+import zio.Task
+import zio.Trace
+import zio.UIO
+import zio.Unsafe
+import zio.ZEnvironment
+import zio.ZIO
+import zio.durationInt
+import zio.test.Assertion.*
+import zio.test.*
+
+object IterableSubscriberSpec extends ZIOSpecDefault {
+  override def spec =
+    suite("IterableSubscriberSpec")(
+      test("works with a well behaved `Publisher`") {
+        assertZIO(publish(seq, None))(succeeds(equalTo(seq)))
+      },
+      test("fails with an initially failed `Publisher`") {
+        assertZIO(publish(Chunk.empty, Some(e)))(fails(equalTo(e)))
+      },
+      test("fails with an eventually failing `Publisher`") {
+        assertZIO(publish(seq, Some(e)))(fails(equalTo(e)))
+      },
+      test("does not fail a fiber on failing `Publisher`") {
+
+        val publisher = new Publisher[Int] {
+          override def subscribe(s: Subscriber[? >: Int]): Unit =
+            s.onSubscribe(
+              new Subscription {
+                override def request(n: Long): Unit = s.onError(new Throwable("boom!"))
+                override def cancel(): Unit         = ()
+              },
+            )
+        }
+
+        val supervisor =
+          new Supervisor[Boolean] {
+
+            override def onStart[R, E, A](
+              environment: ZEnvironment[R],
+              effect: ZIO[R, E, A],
+              parent: Option[Fiber.Runtime[Any, Any]],
+              fiber: Fiber.Runtime[E, A],
+            )(implicit unsafe: Unsafe): Unit = ()
+
+            override def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit
+              unsafe: Unsafe,
+            ): Unit =
+              if (value.isFailure) failedAFiber = true
+
+            @transient var failedAFiber = false // scalafix:ok
+
+            def value(implicit trace: Trace): UIO[Boolean] =
+              ZIO.succeed(failedAFiber)
+
+          }
+
+        for {
+          runtime <- Runtime.addSupervisor(supervisor).toRuntime
+          exit    <- runtime.run(publisher.toChunk.exit)
+          failed  <- supervisor.value
+        } yield assert(exit)(fails(anything)) && assert(failed)(isFalse)
+
+      },
+      test("cancels subscription when interrupted before subscription") {
+        val tst =
+          for {
+            subscriberP    <- Promise.make[Nothing, Subscriber[?]]
+            cancelledLatch <- Promise.make[Nothing, Unit]
+
+            subscription = new Subscription {
+              override def request(n: Long): Unit = ()
+              override def cancel(): Unit         = cancelledLatch.unsafe.done(ZIO.unit)
+            }
+            probe = new Publisher[Int] {
+              override def subscribe(subscriber: Subscriber[? >: Int]): Unit =
+                subscriberP.unsafe.done(ZIO.succeed(subscriber))
+            }
+
+            fiber      <- probe.toChunk.fork
+            subscriber <- subscriberP.await
+            _          <- fiber.interrupt
+            _          <- ZIO.succeed(subscriber.onSubscribe(subscription))
+            _          <- cancelledLatch.await
+          } yield ()
+
+        assertZIO(tst.exit)(succeeds(anything))
+      } @@ TestAspect.nonFlaky @@ TestAspect.timeout(60.seconds),
+      test("cancels subscription when interrupted after subscription") {
+        withProbe(probe =>
+          assertZIO((for {
+            fiber <- probe.toChunk.fork
+            _     <- ZIO.attemptBlockingInterrupt(probe.expectRequest())
+            _     <- fiber.interrupt
+            _     <- ZIO.attemptBlockingInterrupt(probe.expectCancelling())
+          } yield ()).exit)(
+            succeeds(isUnit),
+          ),
+        )
+      } @@ TestAspect.nonFlaky @@ TestAspect.timeout(60.seconds),
+      test("cancels subscription when interrupted during consumption") {
+        withProbe(probe =>
+          assertZIO((for {
+            fiber <- probe.toChunk.fork
+            _     <- ZIO.attemptBlockingInterrupt(probe.expectRequest())
+            _     <- ZIO.attempt((1 to 10).foreach(i => probe.sendNext(i)))
+            _     <- fiber.interrupt
+            _     <- ZIO.attemptBlockingInterrupt(probe.expectCancelling())
+          } yield ()).exit)(
+            succeeds(isUnit),
+          ),
+        )
+      } @@ TestAspect.nonFlaky @@ TestAspect.timeout(60.seconds),
+    )
+
+  val e: Throwable    = new RuntimeException("boom")
+  val seq: Chunk[Int] = Chunk.fromIterable(List.range(0, 100))
+
+  def withProbe[R, E0, E >: Throwable, A](f: ManualPublisher[Int] => ZIO[R, E, A]): ZIO[R, E, A] = {
+    val testEnv = new TestEnvironment(5000, 500)
+    val probe   = new ManualPublisher[Int](testEnv)
+    f(probe) <* ZIO.attempt(testEnv.verifyNoAsyncErrorsNoDelay())
+  }
+
+  def publish(seq: Chunk[Int], failure: Option[Throwable]): UIO[Exit[Throwable, Chunk[Int]]] = {
+
+    def loop(probe: ManualPublisher[Int], remaining: Chunk[Int]): Task[Unit] =
+      for {
+        n <- ZIO.attemptBlockingInterrupt(probe.expectRequest())
+        split         = n.toInt
+        (nextN, tail) = remaining.splitAt(split)
+        _ <- ZIO.attempt(nextN.foreach(probe.sendNext))
+        _ <-
+          if (nextN.size < split)
+            ZIO.attempt(failure.fold(probe.sendCompletion())(probe.sendError))
+          else loop(probe, tail)
+      } yield ()
+
+    val faillable =
+      withProbe(probe =>
+        for {
+          fiber <- probe.toChunk.fork
+          _     <- loop(probe, seq)
+          r     <- fiber.join
+        } yield r,
+      )
+
+    faillable.exit
+  }
+}

--- a/driver/src/test/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/SingleElementSubscriberSpec.scala
+++ b/driver/src/test/scala/io/github/zeal18/zio/mongodb/driver/reactivestreams/SingleElementSubscriberSpec.scala
@@ -1,0 +1,170 @@
+package io.github.zeal18.zio.mongodb.driver.reactivestreams
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import org.reactivestreams.tck.TestEnvironment
+import org.reactivestreams.tck.TestEnvironment.ManualPublisher
+import zio.Chunk
+import zio.Exit
+import zio.Fiber
+import zio.Runtime
+import zio.Supervisor
+import zio.Task
+import zio.Trace
+import zio.UIO
+import zio.Unsafe
+import zio.ZEnvironment
+import zio.ZIO
+import zio.durationInt
+import zio.test.Assertion.*
+import zio.test.*
+
+object SingleElementSubscriberSpec extends ZIOSpecDefault {
+  override def spec =
+    suite("SingleElementSubscriberSpec")(
+      test("works with a well behaved `Publisher`") {
+        assertZIO(publish(seq, None))(succeeds(equalTo(seq.headOption)))
+      },
+      test("fails with an initially failed `Publisher`") {
+        assertZIO(publish(Chunk.empty, Some(e)))(fails(equalTo(e)))
+      },
+      test("returns None when completed without elements") {
+        withProbe(probe =>
+          assertZIO((for {
+            fiber  <- probe.headOption.fork
+            _      <- ZIO.attemptBlockingInterrupt(probe.expectRequest())
+            _      <- ZIO.attempt(probe.sendCompletion())
+            result <- fiber.join
+          } yield result).exit)(
+            succeeds(isNone),
+          ),
+        )
+      } @@ TestAspect.timeout(60.seconds),
+      test("does not fail a fiber on failing `Publisher`") {
+
+        val publisher = new Publisher[Int] {
+          override def subscribe(s: Subscriber[? >: Int]): Unit =
+            s.onSubscribe(
+              new Subscription {
+                override def request(n: Long): Unit = s.onError(new Throwable("boom!"))
+                override def cancel(): Unit         = ()
+              },
+            )
+        }
+
+        val supervisor =
+          new Supervisor[Boolean] {
+
+            override def onStart[R, E, A](
+              environment: ZEnvironment[R],
+              effect: ZIO[R, E, A],
+              parent: Option[Fiber.Runtime[Any, Any]],
+              fiber: Fiber.Runtime[E, A],
+            )(implicit unsafe: Unsafe): Unit = ()
+
+            override def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit
+              unsafe: Unsafe,
+            ): Unit =
+              if (value.isFailure) failedAFiber = true
+
+            @transient var failedAFiber = false // scalafix:ok
+
+            def value(implicit trace: Trace): UIO[Boolean] =
+              ZIO.succeed(failedAFiber)
+
+          }
+
+        for {
+          runtime <- Runtime.addSupervisor(supervisor).toRuntime
+          exit    <- runtime.run(publisher.headOption.exit)
+          failed  <- supervisor.value
+        } yield assert(exit)(fails(anything)) && assert(failed)(isFalse)
+
+      },
+      test("cancels subscription when interrupted before subscription") {
+        val tst =
+          for {
+            subscriberP    <- Promise.make[Nothing, Subscriber[?]]
+            cancelledLatch <- Promise.make[Nothing, Unit]
+
+            subscription = new Subscription {
+              override def request(n: Long): Unit = ()
+              override def cancel(): Unit         = cancelledLatch.unsafe.done(ZIO.unit)
+            }
+            probe = new Publisher[Int] {
+              override def subscribe(subscriber: Subscriber[? >: Int]): Unit =
+                subscriberP.unsafe.done(ZIO.succeed(subscriber))
+            }
+
+            fiber      <- probe.headOption.fork
+            subscriber <- subscriberP.await
+            _          <- fiber.interrupt
+            _          <- ZIO.succeed(subscriber.onSubscribe(subscription))
+            _          <- cancelledLatch.await
+          } yield ()
+
+        assertZIO(tst.exit)(succeeds(anything))
+      } @@ TestAspect.nonFlaky @@ TestAspect.timeout(60.seconds),
+      test("cancels subscription when interrupted after subscription") {
+        withProbe(probe =>
+          assertZIO((for {
+            fiber <- probe.headOption.fork
+            _     <- ZIO.attemptBlockingInterrupt(probe.expectRequest())
+            _     <- fiber.interrupt
+            _     <- ZIO.attemptBlockingInterrupt(probe.expectCancelling())
+          } yield ()).exit)(
+            succeeds(isUnit),
+          ),
+        )
+      } @@ TestAspect.nonFlaky @@ TestAspect.timeout(60.seconds),
+      test("cancels subscription when interrupted during consumption") {
+        withProbe(probe =>
+          assertZIO((for {
+            fiber <- probe.headOption.fork
+            _     <- ZIO.attemptBlockingInterrupt(probe.expectRequest())
+            _     <- ZIO.attempt((1 to 10).foreach(i => probe.sendNext(i)))
+            _     <- fiber.interrupt
+            _     <- ZIO.attemptBlockingInterrupt(probe.expectCancelling())
+          } yield ()).exit)(
+            succeeds(isUnit),
+          ),
+        )
+      } @@ TestAspect.nonFlaky @@ TestAspect.timeout(60.seconds),
+    )
+
+  val e: Throwable    = new RuntimeException("boom")
+  val seq: Chunk[Int] = Chunk.fromIterable(List.range(0, 100))
+
+  def withProbe[R, E0, E >: Throwable, A](f: ManualPublisher[Int] => ZIO[R, E, A]): ZIO[R, E, A] = {
+    val testEnv = new TestEnvironment(5000, 500)
+    val probe   = new ManualPublisher[Int](testEnv)
+    f(probe) <* ZIO.attempt(testEnv.verifyNoAsyncErrorsNoDelay())
+  }
+
+  def publish(seq: Chunk[Int], failure: Option[Throwable]): UIO[Exit[Throwable, Option[Int]]] = {
+
+    def loop(probe: ManualPublisher[Int], remaining: Chunk[Int]): Task[Unit] =
+      for {
+        n <- ZIO.attemptBlockingInterrupt(probe.expectRequest())
+        split         = n.toInt
+        (nextN, tail) = remaining.splitAt(split)
+        _ <- ZIO.attempt(nextN.foreach(probe.sendNext))
+        _ <-
+          if (nextN.size < split)
+            ZIO.attempt(failure.fold(probe.sendCompletion())(probe.sendError))
+          else loop(probe, tail)
+      } yield ()
+
+    val faillable =
+      withProbe(probe =>
+        for {
+          fiber <- probe.headOption.fork
+          _     <- loop(probe, seq)
+          r     <- fiber.join
+        } yield r,
+      )
+
+    faillable.exit
+  }
+}


### PR DESCRIPTION
The PR implements the following in-memory subscribers:
* iterable
* single element
* empty

for some cases it's too much to create a stream, implemented subscribers are an attempt to avoid invoking ZStream machinery when data could easily fin into memory (especially for the empty subscriber which ignores data at all)